### PR TITLE
(WIP) Fix to save a Comment in Django 1.5

### DIFF
--- a/django_comments_xtd/views.py
+++ b/django_comments_xtd/views.py
@@ -9,7 +9,7 @@ from django.template import loader, Context, RequestContext
 from django.utils.translation import ugettext_lazy as _
 from django_comments_xtd import signals, signed
 from django_comments_xtd.conf import settings
-from django_comments_xtd.models import (XtdComment, TmpXtdComment, 
+from django_comments_xtd.models import (XtdComment, TmpXtdComment,
                                         max_thread_level_for_content_type)
 from django_comments_xtd.utils import send_mail
 
@@ -18,8 +18,8 @@ def send_email_confirmation_request(comment, target, key, text_template="django_
     """Send email requesting comment confirmation"""
     subject = _("comment confirmation request")
     confirmation_url = reverse("comments-xtd-confirm", args=[key])
-    message_context = Context({ 'comment': comment, 
-                                'content_object': target, 
+    message_context = Context({ 'comment': comment,
+                                'content_object': target,
                                 'confirmation_url': confirmation_url,
                                 'contact': settings.DEFAULT_FROM_EMAIL,
                                 'site': Site.objects.get_current() })
@@ -38,7 +38,7 @@ def _comment_exists(comment):
     True if exists a XtdComment with same user_name, user_email and submit_date.
     """
     return (XtdComment.objects.filter(
-            user_name=comment.user_name, 
+            user_name=comment.user_name,
             user_email=comment.user_email,
             submit_date=comment.submit_date).count() > 0)
 
@@ -47,25 +47,30 @@ def _create_comment(tmp_comment):
     """
     Creates a XtdComment from a TmpXtdComment.
     """
-    comment = XtdComment(**tmp_comment)
+    # Get all data out of the comment object as a dict. Don't take over keys
+    # starting with an underscore.
+    comment = {}
+    for k, v in tmp_comment.__dict__.iteritems():
+        if not k.startswith('_'):
+            comment[k] = v
+    comment = XtdComment(**comment)
     comment.is_public = True
     comment.save()
     return comment
 
-
 def on_comment_was_posted(sender, comment, request, **kwargs):
     """
     Post the comment if a user is authenticated or send a confirmation email.
-    
-    On signal django.contrib.comments.signals.comment_was_posted check if the 
-    user is authenticated or if settings.COMMENTS_XTD_CONFIRM_EMAIL is False. 
+
+    On signal django.contrib.comments.signals.comment_was_posted check if the
+    user is authenticated or if settings.COMMENTS_XTD_CONFIRM_EMAIL is False.
     In both cases will post the comment. Otherwise will send a confirmation
     email to the person who posted the comment.
     """
     if settings.COMMENTS_APP != "django_comments_xtd":
         return False
 
-    if (not settings.COMMENTS_XTD_CONFIRM_EMAIL or 
+    if (not settings.COMMENTS_XTD_CONFIRM_EMAIL or
         (comment.user and comment.user.is_authenticated())):
         if not _comment_exists(comment):
             new_comment = _create_comment(comment)
@@ -76,7 +81,7 @@ def on_comment_was_posted(sender, comment, request, **kwargs):
         object_pk = request.POST["object_pk"]
         model = models.get_model(*ctype.split("."))
         target = model._default_manager.get(pk=object_pk)
-        key = signed.dumps(comment, compress=True, 
+        key = signed.dumps(comment, compress=True,
                            extra_key=settings.COMMENTS_XTD_SALT)
         send_email_confirmation_request(comment, target, key)
 
@@ -91,13 +96,13 @@ def sent(request):
     except (TypeError, ValueError, XtdComment.DoesNotExist):
         template_arg = ["django_comments_xtd/posted.html",
                         "comments/posted.html"]
-        return render_to_response(template_arg, 
+        return render_to_response(template_arg,
                                   context_instance=RequestContext(request))
     else:
         if request.is_ajax() and comment.user and comment.user.is_authenticated():
             template_arg = [
                 "django_comments_xtd/%s/%s/comment.html" % (
-                    comment.content_type.app_label, 
+                    comment.content_type.app_label,
                     comment.content_type.model),
                 "django_comments_xtd/%s/comment.html" % (
                     comment.content_type.app_label,),
@@ -128,7 +133,7 @@ def confirm(request, key, template_discarded="django_comments_xtd/discarded.html
     # Check whether a signal receiver decides to discard the contact_msg
     for (receiver, response) in responses:
         if response == False:
-            return render_to_response(template_discarded, 
+            return render_to_response(template_discarded,
                                       {'comment': tmp_comment},
                                       context_instance=RequestContext(request))
 
@@ -141,7 +146,7 @@ def notify_comment_followers(comment):
     followers = {}
 
     previous_comments = XtdComment.objects.filter(
-        object_pk=comment.object_pk, is_public=True, 
+        object_pk=comment.object_pk, is_public=True,
         followup=True).exclude(id__exact=comment.id)
 
     for instance in previous_comments:
@@ -156,8 +161,8 @@ def notify_comment_followers(comment):
 
     for email, name in followers.iteritems():
         message_context = Context({ 'user_name': name,
-                                    'comment': comment, 
-                                    'content_object': target, 
+                                    'comment': comment,
+                                    'content_object': target,
                                     'site': Site.objects.get_current() })
         text_message = text_message_template.render(message_context)
         html_message = html_message_template.render(message_context)
@@ -172,7 +177,7 @@ def reply(request, cid):
 
     if comment.level == max_thread_level_for_content_type(comment.content_type):
         return render_to_response(
-            "django_comments_xtd/max_thread_level.html", 
+            "django_comments_xtd/max_thread_level.html",
             {'max_level': settings.COMMENTS_XTD_MAX_THREAD_LEVEL},
             context_instance=RequestContext(request))
 
@@ -181,12 +186,12 @@ def reply(request, cid):
 
     template_arg = [
         "django_comments_xtd/%s/%s/reply.html" % (
-            comment.content_type.app_label, 
+            comment.content_type.app_label,
             comment.content_type.model),
         "django_comments_xtd/%s/reply.html" % (
             comment.content_type.app_label,),
         "django_comments_xtd/reply.html"
     ]
-    return render_to_response(template_arg, 
+    return render_to_response(template_arg,
                               {"comment": comment, "form": form, "next": next },
                               context_instance=RequestContext(request))


### PR DESCRIPTION
**This is work in progress**

In my project using Django 1.5 I can not save a comment due to that the `**Comment` instance cannot be used as initials for a `XtdComment` instance. I had to convert the `Comment` to a dictionary first and also removing attributes starting with an underscore. 

This is kind of a hot fix at the moment, the `XtdComment(**Comment)` is quite a common pattern for me too, and I dont know if this is really just not working since Django 1.5 or if Python is involved.

For whats it worth, the test suite runs fine under Django 1.5.

So yeah, need more investigation but I'm opening a pull request in case somebody else ran into this. 

The full traceback was:

```
Traceback:
File "/Users/martin/.virtualenv/project/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  115.                         response = callback(request, *callback_args, **callback_kwargs)
File "/Users/martin/.virtualenv/project/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  91.                     response = view_func(request, *args, **kwargs)
File "/Users/martin/.virtualenv/project/lib/python2.7/site-packages/django/views/decorators/http.py" in inner
  41.             return func(request, *args, **kwargs)
File "/Users/martin/.virtualenv/project/lib/python2.7/site-packages/django/contrib/comments/views/comments.py" in post_comment
  128.         request=request
File "/Users/martin/.virtualenv/project/lib/python2.7/site-packages/django/dispatch/dispatcher.py" in send
  170.             response = receiver(signal=self, sender=sender, **named)
File "/Users/martin/.virtualenv/project/lib/python2.7/site-packages/django_comments_xtd/views.py" in on_comment_was_posted
  72.             new_comment = _create_comment(comment)
File "/Users/martin/.virtualenv/project/lib/python2.7/site-packages/django_comments_xtd/views.py" in _create_comment
  55.     comment = XtdComment(**tmp_comment)

Exception Type: TypeError at /forum/post/
Exception Value: ModelBase object argument after ** must be a mapping, not Comment
```
