### PR TITLE
Follow-up potentially sent to non-followers

### DIFF
--- a/django_comments_xtd/views.py
+++ b/django_comments_xtd/views.py
@@ -142,7 +142,8 @@ def notify_comment_followers(comment):
     followers = {}
 
     previous_comments = XtdComment.objects.filter(
-        object_pk=comment.object_pk, is_public=True, 
+        content_type=comment.content_type,
+        object_pk=comment.object_pk, is_public=True,
         followup=True).exclude(id__exact=comment.id)
 
     for instance in previous_comments:


### PR DESCRIPTION
in https://github.com/danirus/django-comments-xtd/blob/master/django_comments_xtd/views.py#L144, the query selecting followers is not filtering by content-type.

Consider the following scenario:
1. user Charlie is subscribed to model Diary, pk=1
2. user Bob is subscribed to model Story, pk=1
3. user Alice comments on Story, pk=1
4. both Charlie and Bob receives a followup email

The fix should be pretty and I wrote a test for it, but it seems to hang on when calling `mail_sent_queue.get(block=True)` and I can't figure out why. Testing on Python 2.7.6 and happens both on Django 1.5 and 1.6.
