### PR TITLE
Add markup fallback filter setting

### DIFF
--- a/django_comments_xtd/conf/defaults.py
+++ b/django_comments_xtd/conf/defaults.py
@@ -23,6 +23,9 @@ COMMENTS_XTD_FORM_CLASS = "django_comments_xtd.forms.XtdCommentForm"
 # Model to use
 COMMENTS_XTD_MODEL = "django_comments_xtd.models.XtdComment"
 
+# Default markup filter to use
+COMMENTS_XTD_MARKUP_FALLBACK_FILTER = None
+
 # Send HTML emails
 COMMENTS_XTD_SEND_HTML_EMAIL = True
 

--- a/django_comments_xtd/tests/test_templatetags.py
+++ b/django_comments_xtd/tests/test_templatetags.py
@@ -1,5 +1,6 @@
 #-*- coding: utf-8 -*-
 
+from mock import patch
 import unittest
 
 from django.template import TemplateSyntaxError
@@ -38,6 +39,30 @@ def fib():
         a, b = b, a + b
 </pre>
 ''')
+
+
+@unittest.skipIf(not formatter, "This test case needs django-markup, docutils and markdown installed to be run")
+class RenderFallbackMarkupValueFilterTestCase(DjangoTestCase):
+
+    @patch.multiple('django_comments_xtd.conf.settings',
+                    COMMENTS_XTD_MARKUP_FALLBACK_FILTER='markdown')
+    def test_render_fallback_markup_comment(self):
+        with patch.multiple('django_comments_xtd.conf.settings',
+                            COMMENTS_XTD_MARKUP_FALLBACK_FILTER='markdown'):
+            comment = r'''An [example](http://url.com/ "Title")'''
+            result = render_markup_comment(comment)
+            self.assertEqual(result,
+                             '<p>An <a href="http://url.com/" title="Title">example</a></p>')
+
+    @patch.multiple('django_comments_xtd.conf.settings',
+                    COMMENTS_XTD_MARKUP_FALLBACK_FILTER=None)
+    def test_render_fallback_markup_comment(self):
+        with patch.multiple('django_comments_xtd.conf.settings',
+                            COMMENTS_XTD_MARKUP_FALLBACK_FILTER=None):
+            comment = r'''An [example](http://url.com/ "Title")'''
+            result = render_markup_comment(comment)
+            self.assertEqual(result,
+                             r'''An [example](http://url.com/ "Title")''')
 
 
 @unittest.skipIf(formatter, "This test case needs django-markup or docutils or markdown not installed to be run")

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -98,6 +98,22 @@ An example::
 Defaults to `"django_comments_xtd.models.XtdComment"`.
 
 
+Comment Markup Fallback Filter
+==============================
+
+:index:`COMMENTS_XTD_MARKUP_FALLBACK_FILTER` - Default filter to use when rendering comments
+
+**Optional**
+
+Indicate the default markup filter for comments. This value must be a key in the MARKUP_FILTER setting. If not specified or None, comments that do not indicate an intended markup filter are simply returned as plain text.
+
+An example::
+
+    COMMENTS_XTD_MARKUP_FALLBACK_FILTER = 'markdown'
+
+Defaults to None.
+
+
 Salt
 ====
 


### PR DESCRIPTION
This setting allows a developer to choose a default markup filter that will be applied to all non-identified comments. The intent of this is to allow comments more like Reddit (for example), where every comment is interpreted as Markdown, even if the comment does not specify its markup filter in the first line with `#!markdown`.

All other normal operation is preserved.

If the setting is None or is not specified in `settings.py`, this change keeps the normal behavior of returning the comment plaintext.

This change does not interfere with the normal operation where a comment identifies its own markup, eg:

    #!restructuredtext
    
    ...

will be processed as reStructuredText.

Documentation is included, as well as two additional passing tests.