### PR TITLE
Fixed bugs so works with Django 1.9 and Python 2.7

### DIFF
--- a/django_comments_xtd/models.py
+++ b/django_comments_xtd/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.db.models import F, Max, Min
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext, ugettext_lazy as _
+from django.utils.encoding import force_text
 
 try:
     from django.db.transaction import atomic
@@ -59,6 +60,17 @@ class XtdCommentManager(models.Manager):
         qs = self.get_queryset().filter(content_type__in=content_types)\
                                 .reverse()
         return qs
+
+    def for_model(self, model):
+        """
+        QuerySet for all comments for a particular model (either an instance or
+        a class).
+        """
+        ct = ContentType.objects.get_for_model(model)
+        qs = self.get_queryset().filter(content_type=ct)
+        if isinstance(model, models.Model):
+            qs = qs.filter(object_pk=force_text(model._get_pk_val()))
+            return qs
 
 
 class XtdComment(Comment):

--- a/django_comments_xtd/templatetags/comments_xtd.py
+++ b/django_comments_xtd/templatetags/comments_xtd.py
@@ -1,5 +1,8 @@
 import hashlib
-import urllib
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
 import re
 
 from django.contrib.contenttypes.models import ContentType
@@ -344,7 +347,7 @@ register.filter(render_markup_comment)
 def xtd_comment_gravatar_url(email, size=48):
     return ("http://www.gravatar.com/avatar/%s?%s&d=mm" %
             (hashlib.md5(email.lower().encode('utf-8')).hexdigest(),
-             urllib.parse.urlencode({'s': str(size)})))
+             urlencode({'s': str(size)})))
 
 
 register.filter(xtd_comment_gravatar_url)


### PR DESCRIPTION
I found that, using Django 1.9, I got the error `XtdCommentManager has no method 'for_model'` if I tried to use the `get_xtdcomment_tree` template tag. Having added that method (copying it from the [CommentManager](https://github.com/django/django-contrib-comments/blob/master/django_comments/managers.py#L6) class of django_comments) I also realized that the use of `urllib.parse` makes the app incompatible with Python 2, as that library was organized differently. I added some logic to figure out which library name to use.