### PR TITLE
Misleading confirmation email due to slice

### DIFF
--- a/django_comments_xtd/templates/django_comments_xtd/email_confirmation_request.html
+++ b/django_comments_xtd/templates/django_comments_xtd/email_confirmation_request.html
@@ -10,7 +10,7 @@
 
 <p>If you do not wish to post the comment, please ignore this message or report an incident to {{ contact }}. Otherwise click on the link below to confirm the comment.</p>
 
-<p><a href="http://{{ site.domain }}{{ confirmation_url }}">http://{{ site.domain }}{{ confirmation_url|slice:":40" }}...</a></p>
+<p><a href="http://{{ site.domain }}{{ confirmation_url }}">http://{{ site.domain }}{{ confirmation_url }}...</a></p>
 
 <p>If clicking does not work, you can also copy and paste the address into your browser's address window.</p>
 


### PR DESCRIPTION
In the [email_confirmation_request.html](https://github.com/danirus/django-comments-xtd/blob/master/django_comments_xtd/templates/django_comments_xtd/email_confirmation_request.html#L13-L15), it states that if the link doesn't work when clicked, it can be copied into the browser window, however, the link displayed is truncated to 40 characters. so copy/pasting the link will not work.

This change removes the slice operator so that the link can be copy/pasted.