### PR TITLE
Reduce length of generated confirmation emails.

### DIFF
--- a/django_comments_xtd/models.py
+++ b/django_comments_xtd/models.py
@@ -1,5 +1,3 @@
-import six
-
 import django
 from django.db import models
 from django.db.models import F, Max, Min
@@ -230,7 +228,7 @@ class TmpXtdComment(dict):
         )
 
     def __reduce__(self):
-        state = { k:v for k, v in self.items() if k != 'content_object' }
+        state = {k: v for k, v in self.items() if k != 'content_object'}
         ct = state.pop('content_type')
         state['content_type_key'] = ct.natural_key()
         return (TmpXtdComment, (), state)

--- a/django_comments_xtd/models.py
+++ b/django_comments_xtd/models.py
@@ -218,8 +218,22 @@ class TmpXtdComment(dict):
         else:
             return ""
 
+    def __setstate__(self, state):
+        ct_key = state.pop('content_type_key')
+        ctype = ContentType.objects.get_by_natural_key(*ct_key)
+        self.update(
+            state,
+            content_type=ctype,
+            content_object=ctype.get_object_for_this_type(
+                pk=state['object_pk']
+            )
+        )
+
     def __reduce__(self):
-        return (TmpXtdComment, (), None, None, six.iteritems(self))
+        state = { k:v for k, v in self.items() if k != 'content_object' }
+        ct = state.pop('content_type')
+        state['content_type_key'] = ct.natural_key()
+        return (TmpXtdComment, (), state)
 
 
 # ----------------------------------------------------------------------

--- a/django_comments_xtd/tests/test_views.py
+++ b/django_comments_xtd/tests/test_views.py
@@ -59,10 +59,10 @@ class ConfirmCommentTestCase(TestCase):
         patcher = patch('django_comments_xtd.views.send_mail')
         self.mock_mailer = patcher.start()
         # Create random string so that it's harder for zlib to compress
-        content = ''.join([random.choice(string.printable) for _ in range(6096)])
+        content = ''.join(random.choice(string.printable) for _ in range(6096))
         self.article = Article.objects.create(title="September",
                                               slug="september",
-                                              body="What I did on September..." + content)
+                                              body="In September..." + content)
         self.form = django_comments.get_form()(self.article)
         data = {"name": "Bob", "email": "bob@example.com", "followup": True,
                 "reply_to": 0, "level": 1, "order": 1,
@@ -81,7 +81,8 @@ class ConfirmCommentTestCase(TestCase):
                                         follow=True)
 
     def test_confirm_url_is_short_enough(self):
-        # Tests that the confirm url's length isn't dependent on the article length
+        # Tests that the length of the confirm url's length isn't
+        # dependent on the article length.
         l = len(reverse("comments-xtd-confirm",
                         kwargs={'key': self.key}))
         print("\nXXXXXXXXXXX:", l)

--- a/django_comments_xtd/views.py
+++ b/django_comments_xtd/views.py
@@ -124,6 +124,8 @@ def on_comment_was_posted(sender, comment, request, **kwargs):
     else:
         ctype = request.POST["content_type"]
         object_pk = request.POST["object_pk"]
+        # TODO: I'm not sure the next two lines are needed since the target
+        #       should already exist on the comment
         model = get_model(*ctype.split("."))
         target = model._default_manager.get(pk=object_pk)
         key = signed.dumps(comment, compress=True,


### PR DESCRIPTION
This commit removes the `content_object` and `content_type` model instances
from the tmp comment instance so that the generated comment confirmation email
isn't so large. It also repopulates these keys when confirming the link.

Fixes: #51