### PR TITLE
Add French translations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,6 @@ include webpack.config.js
 include requirements.pip
 include requirements_tests.pip
 recursive-include docs *
+recursive-include django_comments_xtd/locale *
 recursive-include django_comments_xtd/templates *
 recursive-include django_comments_xtd/static *

--- a/django_comments_xtd/locale/fr/LC_MESSAGES/django.po
+++ b/django_comments_xtd/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,353 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-07-06 17:55+0200\n"
+"PO-Revision-Date: 2017-07-06 15:08+0053\n"
+"Last-Translator: b'Administrator  <admin@example.com>'\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Translated-Using: django-rosetta 0.7.13\n"
+
+#: api/serializers.py:189 templates/comments/list.html:16
+#: templates/django_comments_xtd/comment.html:15
+#: templates/django_comments_xtd/comment_tree.html:33
+msgid "This comment has been removed."
+msgstr "Ce commentaire a été supprimé."
+
+#: forms.py:13
+msgid "Notify me about follow-up comments"
+msgstr "Avertissez-moi des commentaires suivants"
+
+#: forms.py:28
+msgid "name"
+msgstr "nom"
+
+#: forms.py:31
+msgid "Mail"
+msgstr "Email"
+
+#: forms.py:31
+msgid "Required for comment verification"
+msgstr "Requis pour la vérification des commentaires"
+
+#: forms.py:32
+msgid "mail address"
+msgstr "adresse email"
+
+#: forms.py:35
+msgid "Link"
+msgstr "Lien"
+
+#: forms.py:37
+msgid "url your name links to (optional)"
+msgstr "Lien à afficher sur votre nom (optionnel)"
+
+#: forms.py:40
+msgid "Your comment"
+msgstr "Votre commentaire"
+
+#: models.py:65
+msgid "Notify follow-up comments"
+msgstr "Avertir des commentaires suivants"
+
+#: templates/comments/delete.html:5
+msgid "Remove comment"
+msgstr "Supprimer le commentaire"
+
+#: templates/comments/delete.html:14
+msgid "Remove this comment?"
+msgstr "Supprimer le commentaire ?"
+
+#: templates/comments/delete.html:15
+msgid ""
+"As a moderator you can delete comments. Deleting a comment does not remove "
+"it from the site, only prevents your website from showing the text. Click on "
+"the remove button to delete the following comment:"
+msgstr ""
+"En tant que modérateur, vous pouvez supprimer les commentaires. La "
+"suppression d'un commentaire ne l'exclut pas du site, elle empêche juste "
+"votre site d'afficher le texte. Cliquez sur le bouton Supprimer pour "
+"supprimer le commentaire suivant :"
+
+#: templates/comments/delete.html:51
+msgid "Remove"
+msgstr "Supprimer"
+
+#: templates/comments/deleted.html:5
+msgid "Comment removed"
+msgstr "Commentaire supprimé"
+
+#: templates/comments/deleted.html:12
+msgid "The comment has been removed."
+msgstr "Le commentaire a été supprimé."
+
+#: templates/comments/deleted.html:13 templates/comments/flagged.html:13
+msgid ""
+"Thank you for taking the time to improve the quality of discussion in our "
+"site."
+msgstr ""
+"Merci d'avoir pris le temps d'améliorer la qualité de la discussion sur "
+"notre site."
+
+#: templates/comments/flag.html:5
+msgid "Flag comment"
+msgstr "Signaler un commentaire"
+
+#: templates/comments/flag.html:12
+msgid "Flag this comment?"
+msgstr "Signaler ce commentaire ?"
+
+#: templates/comments/flag.html:13
+msgid ""
+"Click on the flag button to mark the following comment as inappropriate."
+msgstr ""
+"Cliquez sur le bouton signaler pour marquer le commentaire suivant comme "
+"inapproprié."
+
+#: templates/comments/flag.html:43
+#: templates/django_comments_xtd/comment.html:11
+#: templates/django_comments_xtd/dislike.html:47
+#: templates/django_comments_xtd/like.html:47
+msgid "Posted to "
+msgstr ""
+
+#: templates/comments/flag.html:58
+msgid "Flag"
+msgstr "Signaler"
+
+#: templates/comments/flag.html:59
+#: templates/django_comments_xtd/dislike.html:73
+#: templates/django_comments_xtd/like.html:73
+msgid "cancel"
+msgstr "annuler"
+
+#: templates/comments/flagged.html:5
+msgid "Comment flagged"
+msgstr "Commentaire signalé"
+
+#: templates/comments/flagged.html:12
+msgid "The comment has been flagged."
+msgstr "Le commentaire a été signalé."
+
+#: templates/comments/list.html:23
+#: templates/django_comments_xtd/comment_tree.html:42
+msgid "Reply"
+msgstr "Répondre"
+
+#: templates/comments/posted.html:5
+msgid "Comment confirmation requested."
+msgstr "Confirmation du commentaire demandée."
+
+#: templates/comments/posted.html:7
+msgid ""
+"A confirmation message has been sent to your\n"
+"  email address. Please, click on the link in the message to confirm\n"
+"  your comment."
+msgstr ""
+"Un message de confirmation a été envoyé à votre\n"
+"adresse email. Veuillez cliquer sur le lien dans le message pour confirmer\n"
+"votre commentaire."
+
+#: templates/comments/preview.html:5 templates/comments/preview.html:9
+msgid "Preview your comment"
+msgstr "Aperçu de votre commentaire"
+
+#: templates/comments/preview.html:11
+msgid "Preview your comment for:"
+msgstr "Aperçu de votre commentaire pour :"
+
+#: templates/comments/preview.html:22
+msgid "Empty comment."
+msgstr "Commentaire vide."
+
+#: templates/django_comments_xtd/comment_list.html:8
+msgid "List of comments"
+msgstr "Liste de commentaires"
+
+#: templates/django_comments_xtd/comment_tree.html:14
+msgid "moderator"
+msgstr "modérateur"
+
+#: templates/django_comments_xtd/comment_tree.html:14
+msgid "comment permalink"
+msgstr "lien permanent du commentaire"
+
+#: templates/django_comments_xtd/comment_tree.html:18
+msgid "comment flagged"
+msgstr "commentaire signalé"
+
+#: templates/django_comments_xtd/comment_tree.html:21
+msgid "flag comment"
+msgstr "signaler le commentaire"
+
+#: templates/django_comments_xtd/comment_tree.html:24
+msgid "remove comment"
+msgstr "supprimer le commentaire"
+
+#: templates/django_comments_xtd/comment_tree.html:26
+#, python-format
+msgid "A user has flagged this comment as inappropriate."
+msgid_plural "%(counter)s users have flagged this comment as inappropriate."
+msgstr[0] "Un utilisateur a signalé ce commentaire comme inapproprié."
+msgstr[1] ""
+"%(counter)s utilisateurs ont signalé ce commentaire comme inapproprié."
+
+#: templates/django_comments_xtd/discarded.html:4
+msgid "Comment discarded"
+msgstr "Commentaire rejeté"
+
+#: templates/django_comments_xtd/discarded.html:7
+msgid "Comment automatically discarded"
+msgstr "Commentaire automatiquement rejeté"
+
+#: templates/django_comments_xtd/discarded.html:8
+msgid "Sorry, your comment has been automatically discarded"
+msgstr "Désolé, votre commentaire a été automatiquement rejeté"
+
+#: templates/django_comments_xtd/dislike.html:5
+#: templates/django_comments_xtd/like.html:5
+msgid "Confirm your opinion"
+msgstr "Confirmer votre opinion"
+
+#: templates/django_comments_xtd/dislike.html:14
+msgid "You didn't like this comment, do you want to change it?"
+msgstr "Vous n'avez pas aimé ce commentaire, voulez-vous le changer?"
+
+#: templates/django_comments_xtd/dislike.html:16
+msgid "Do you dislike this comment?"
+msgstr "Vous n'aimez pas ce commentaire ?"
+
+#: templates/django_comments_xtd/dislike.html:19
+#: templates/django_comments_xtd/like.html:19
+msgid "Please, confirm your opinion about the comment."
+msgstr "Veuillez confirmer votre opinion sur le commentaire."
+
+#: templates/django_comments_xtd/dislike.html:60
+msgid ""
+"Click on the \"withdraw\" button if you want to withdraw your negative "
+"opinion on this comment."
+msgstr ""
+"Cliquez sur le bouton « retirer » si vous souhaitez retirer votre avis "
+"négatif sur ce commentaire."
+
+#: templates/django_comments_xtd/dislike.html:69
+#: templates/django_comments_xtd/like.html:69
+msgid "Withdraw"
+msgstr "Retirer"
+
+#: templates/django_comments_xtd/dislike.html:71
+msgid "I dislike it"
+msgstr "Je ne l'aime pas"
+
+#: templates/django_comments_xtd/disliked.html:4
+msgid "You disliked the comment"
+msgstr "Vous n'avez pas aimé ce commentaire"
+
+#: templates/django_comments_xtd/disliked.html:7
+#: templates/django_comments_xtd/liked.html:7
+msgid "Thanks for taking the time to participate."
+msgstr "Merci d'avoir pris le temps de participer."
+
+#: templates/django_comments_xtd/email_followup_comment.txt:4
+msgid "There is a new comment following up yours."
+msgstr "Il y a un nouveau commentaire qui suit le vôtre."
+
+#: templates/django_comments_xtd/email_followup_comment.txt:20
+msgid "Kind regards"
+msgstr "Cordialement"
+
+#: templates/django_comments_xtd/like.html:14
+msgid "You liked this comment, do you want to change it?"
+msgstr "Vous avez aimé ce commentaire, voulez-vous le changer ?"
+
+#: templates/django_comments_xtd/like.html:16
+msgid "Do you like this comment?"
+msgstr "Aimez-vous ce commentaire ?"
+
+#: templates/django_comments_xtd/like.html:60
+msgid ""
+"Click on the \"withdraw\" button if you want to withdraw your positive "
+"opinion on this comment."
+msgstr ""
+"Cliquez sur le bouton \"retirer\" si vous souhaitez retirer votre opinion "
+"positive sur ce commentaire."
+
+#: templates/django_comments_xtd/like.html:71
+msgid "I like it"
+msgstr "J'aime"
+
+#: templates/django_comments_xtd/liked.html:4
+msgid "Your opinion is appreciated"
+msgstr "Votre avis est apprécié"
+
+#: templates/django_comments_xtd/moderated.html:4
+msgid "Comment requires approval"
+msgstr "Le commentaire nécessite une approbation"
+
+#: templates/django_comments_xtd/moderated.html:7
+msgid "Comment in moderation"
+msgstr "Commentaire en modération"
+
+#: templates/django_comments_xtd/moderated.html:9
+msgid ""
+"\n"
+"  Your comment is in moderation.<br/>\n"
+"  It has to be reviewed before being published.<br/>\n"
+"  Thank you for your patience and understanding.\n"
+"  "
+msgstr ""
+"\n"
+"Votre commentaire est en modération. <br/>\n"
+"Il doit être revu avant d'être publié. <br/>\n"
+"Merci pour votre patience et votre compréhension."
+
+#: templates/django_comments_xtd/moderated.html:17
+#, python-format
+msgid ""
+"\n"
+"  Go back to <a href=\"%(content_object_url)s\">%(content_object_str)s</a>\n"
+"  "
+msgstr ""
+"\n"
+"Revenir à <a href=\"%(content_object_url)s\">%(content_object_str)s</a>"
+
+#: templates/django_comments_xtd/muted.html:4
+msgid "Comment thread muted"
+msgstr "Notifications du fil de commentaire enlevée"
+
+#: templates/django_comments_xtd/muted.html:7
+msgid "Comment thread has been muted"
+msgstr "Les notifications du fil de commentaires ont été coupées"
+
+#: templates/django_comments_xtd/muted.html:9
+msgid "You will no longer receive email notifications for comments sent to"
+msgstr ""
+"Vous ne recevrez plus de notifications par email pour les commentaires "
+"envoyés à"
+
+#: templates/django_comments_xtd/reply.html:6
+msgid "Comment reply"
+msgstr "Réponse à un commentaire"
+
+#: templates/django_comments_xtd/reply.html:13
+msgid "Reply to comment"
+msgstr "Répondre à un commentaire"
+
+#: views.py:47
+msgid "comment confirmation request"
+msgstr "Confirmation du commentaire envoyée"
+
+#: views.py:208
+msgid "new comment posted"
+msgstr "nouveau commentaire envoyé"

--- a/django_comments_xtd/locale/fr/LC_MESSAGES/djangojs.po
+++ b/django_comments_xtd/locale/fr/LC_MESSAGES/djangojs.po
@@ -1,0 +1,138 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-07-06 17:59+0200\n"
+"PO-Revision-Date: 2017-07-06 15:15+0053\n"
+"Last-Translator: b'Administrator  <admin@example.com>'\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Translated-Using: django-rosetta 0.7.13\n"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:86
+msgid "moderator"
+msgstr "modérateur"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:117
+msgid "I flagged it as inappropriate"
+msgstr "Je l'ai signalé comme inapproprié"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:126
+msgid "flag comment as inappropriate"
+msgstr "Signaler le commentaire comme inapproprié"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:137
+msgid "remove comment"
+msgstr "Supprimer le commentaire"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:145
+#, javascript-format
+msgid "A user has flagged this comment as inappropriate."
+msgid_plural "%s users have flagged this comment as inappropriate."
+msgstr[0] "Un utilisateur a signalé ce commentaire comme inapproprié."
+msgstr[1] "%s utilisateurs ont signalé ce commentaire comme inapproprié"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:221
+msgid "I like it"
+msgstr "J'aime"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:221
+msgid "I dislike it"
+msgstr "Je n'aime pas"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:284
+msgid "Reply"
+msgstr "Répondre"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:651
+msgid "Your comment"
+msgstr "Votre commentaire"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:682
+msgid "name"
+msgstr "nom"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:689
+msgid "Name"
+msgstr "Nom"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:714
+msgid "mail address"
+msgstr "adresse email"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:715
+msgid "Required for comment verification."
+msgstr "Requis pour la vérification des commentaires."
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:722
+msgid "Mail"
+msgstr "Email"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:751
+msgid "url your name links to (optional)"
+msgstr "Lien à afficher sur votre nom (optionnel)"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:758
+msgid "Link"
+msgstr "Lien"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:775
+msgid "Notify me about follow-up comments"
+msgstr "Avertissez-moi des commentaires suivants"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:827
+msgid "Your comment will be reviewed. Thank your for your patience."
+msgstr "Votre commentaire va être revu. Merci pour votre patience."
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:828
+msgid "Thank you, a comment confirmation request has been sent by mail."
+msgstr ""
+"Merci, une demande de confirmation du commentaire a été envoyé par email."
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:829
+msgid "Sorry, your comment has been rejected."
+msgstr "Désolé, votre commentaire a été rejeté."
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:903
+msgid "Your comment in preview"
+msgstr "Votre commentaire en  aperçu"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:920
+msgid "Now"
+msgstr "Maintenant"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:968
+msgid "preview"
+msgstr "aperçu"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:969
+msgid "send"
+msgstr "envoyer"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:1025
+msgid "Post your comment"
+msgstr "Laissez votre commentaire"
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:1215
+#, javascript-format
+msgid "One comment."
+msgid_plural "%s comments."
+msgstr[0] "Un commentaire."
+msgstr[1] "%s commentaires."
+
+#: static/django_comments_xtd/js/plugin-2.0.0.js:1251
+#, javascript-format
+msgid "There is a new comment."
+msgid_plural "There are %s new comments."
+msgstr[0] "Un nouveau commentaire est disponible."
+msgstr[1] "%s nouveaux commentaires sont disponibles."

--- a/django_comments_xtd/static/django_comments_xtd/js/src/commentform.jsx
+++ b/django_comments_xtd/static/django_comments_xtd/js/src/commentform.jsx
@@ -108,7 +108,7 @@ export class CommentForm extends React.Component {
     return (
       <div className={div_cssc}>
         <label htmlFor="id_name" className="control-label col-lg-3 col-md-3">
-          Name
+          {django.gettext("Name")}
         </label>
         <div className="col-lg-7 col-md-7">
           <input type="text" name="name" required id="id_name"
@@ -137,7 +137,7 @@ export class CommentForm extends React.Component {
     return (
       <div className={div_cssc}>
         <label htmlFor="id_email" className="control-label col-lg-3 col-md-3">
-          Mail
+          {django.gettext("Mail")}
         </label>
         <div className="col-lg-7 col-md-7">
           <input type="text" name="email" required id="id_email"
@@ -165,7 +165,7 @@ export class CommentForm extends React.Component {
     return (
       <div className={div_cssc}>
         <label htmlFor="id_url" className="control-label col-lg-3 col-md-3">
-          Link
+          {django.gettext("Link")}
         </label>
         <div className="col-lg-7 col-md-7">
           <input type="text" name="url" id="id_url" value={this.state.url}

--- a/django_comments_xtd/templates/comments/flag.html
+++ b/django_comments_xtd/templates/comments/flag.html
@@ -40,7 +40,7 @@
     {% with object_absolute_url=comment.content_object.get_absolute_url %}
     {% if object_absolute_url %}
     <p class="text-center">
-      Posted to <a href="{{ object_absolute_url }}">{{ comment.content_object }}</a>
+      {% trans "Posted to "%}&nbsp;<a href="{{ object_absolute_url }}">{{ comment.content_object }}</a>
     </p>
     {% endif %}
     {% endwith %}

--- a/django_comments_xtd/templates/django_comments_xtd/dislike.html
+++ b/django_comments_xtd/templates/django_comments_xtd/dislike.html
@@ -44,7 +44,7 @@
     {% with object_absolute_url=comment.content_object.get_absolute_url %}
     {% if object_absolute_url %}
     <p class="text-center">
-      Posted to <a href="{{ object_absolute_url }}">{{ comment.content_object }}</a>
+      {% trans "Posted to "%}&nbsp;<a href="{{ object_absolute_url }}">{{ comment.content_object }}</a>
     </p>
     {% endif %}
     {% endwith %}

--- a/django_comments_xtd/templates/django_comments_xtd/like.html
+++ b/django_comments_xtd/templates/django_comments_xtd/like.html
@@ -44,7 +44,7 @@
     {% with object_absolute_url=comment.content_object.get_absolute_url %}
     {% if object_absolute_url %}
     <p class="text-center">
-      Posted to <a href="{{ object_absolute_url }}">{{ comment.content_object }}</a>
+      {% trans "Posted to "%}&nbsp;<a href="{{ object_absolute_url }}">{{ comment.content_object }}</a>
     </p>
     {% endif %}
     {% endwith %}

--- a/example/comp/settings.py
+++ b/example/comp/settings.py
@@ -37,6 +37,7 @@ LANGUAGE_CODE = 'en'
 LANGUAGES = (
     ('en', 'English'),
     ('es', 'Spanish'),
+    ('fr', 'French'),
 )
 
 SITE_ID = 1


### PR DESCRIPTION
Three independent commits in the PR in order to use the package in French :
 - fix the manifest to include locale files : the package on pypi doesn't have the files needed for translations
 - change some hard-coded English sentences to be translatable
 - add the French translations