### PR TITLE
Support non-int pks and extract commentbox props for use outside template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ node_modules/
 .eggs
 package-lock.json
 .pytest_cache/
+.venv

--- a/django_comments_xtd/api/frontend.py
+++ b/django_comments_xtd/api/frontend.py
@@ -1,0 +1,118 @@
+from django.contrib.contenttypes.models import ContentType
+from django_comments.forms import CommentSecurityForm
+from django_comments_xtd import get_model as get_comment_model
+from django_comments_xtd.conf import settings
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
+
+XtdComment = get_comment_model()
+
+
+def commentbox_props(obj, user, request=None):
+    """
+    Returns a JSON object with the initial props for the CommentBox component.
+
+    The returned JSON object contains the following attributes::
+        {
+            comment_count: <int>,  // Count of comments posted to the object.
+            allow_comments: <bool>,  // Whether to allow comments to this post.
+            current_user: <str as "user_id:user_name">,
+            is_authenticated: <bool>,  // Whether current_user is authenticated.
+            request_name: <bool>,  // True when auth user has no actual name.
+            request_email_address: <bool>,  // True when auth user has no email.
+            allow_flagging: false,
+            allow_feedback: false,
+            show_feedback: false,
+            can_moderate: <bool>,  // Whether current_user can moderate.
+            poll_interval: 2000, // Check for new comments every 2 seconds.
+            feedback_url: <api-url-to-send-like/dislike-feedback>,
+            delete_url: <api-url-for-moderators-to-remove-comment>,
+            login_url: settings.LOGIN_URL,
+            reply_url: <api-url-to-reply-comments>,
+            flag_url: <api-url-to-suggest-comment-removal>,
+            list_url: <api-url-to-list-comments>,
+            count_url: <api-url-to-count-comments>,
+            send_url: <api-irl-to-send-a-comment>,
+            form: {
+                content_type: <value>,
+                object_pk: <value>,
+                timestamp: <value>,
+                security_hash: <value>
+            },
+            login_url: <only_when_user_is_not_authenticated>,
+            like_url: <only_when_user_is_not_authenticated>,
+            dislike_url: <only_when_user_is_not_authenticated>
+        }
+    """
+
+    def _reverse(*args, **kwargs):
+        """Inject the request, if provided, to generate absolute URLs"""
+        return reverse(*args, request=request, **kwargs)
+
+    form = CommentSecurityForm(obj)
+    ctype = ContentType.objects.get_for_model(obj)
+    queryset = XtdComment.objects.filter(content_type=ctype,
+                                         object_pk=obj.pk,
+                                         site__pk=settings.SITE_ID,
+                                         is_public=True)
+    ctype_slug = "%s-%s" % (ctype.app_label, ctype.model)
+    d = {
+        "comment_count": queryset.count(),
+        "allow_comments": True,
+        "current_user": "0:Anonymous",
+        "request_name": False,
+        "request_email_address": False,
+        "is_authenticated": False,
+        "allow_flagging": False,
+        "allow_feedback": False,
+        "show_feedback": False,
+        "can_moderate": False,
+        "poll_interval": 2000,
+        "feedback_url": _reverse("comments-xtd-api-feedback"),
+        "delete_url": _reverse("comments-delete", args=(0,)),
+        "reply_url": _reverse("comments-xtd-reply", kwargs={'cid': 0}),
+        "flag_url": _reverse("comments-flag", args=(0,)),
+        "list_url": _reverse('comments-xtd-api-list',
+                             kwargs={'content_type': ctype_slug,
+                                     'object_pk': obj.id}),
+        "count_url": _reverse('comments-xtd-api-count',
+                              kwargs={'content_type': ctype_slug,
+                                      'object_pk': obj.id}),
+        "send_url": _reverse("comments-xtd-api-create"),
+        "form": {
+            "content_type": form['content_type'].value(),
+            "object_pk": form['object_pk'].value(),
+            "timestamp": form['timestamp'].value(),
+            "security_hash": form['security_hash'].value()
+        }
+    }
+    try:
+        user_is_authenticated = user.is_authenticated()
+    except TypeError:  # Django >= 1.11
+        user_is_authenticated = user.is_authenticated
+    if user and user_is_authenticated:
+        d['current_user'] = "%d:%s" % (
+            user.pk, settings.COMMENTS_XTD_API_USER_REPR(user))
+        d['is_authenticated'] = True
+        d['can_moderate'] = user.has_perm("django_comments.can_moderate")
+        d['request_name'] = True if not len(user.get_full_name()) else False
+        d['request_email_address'] = True if not user.email else False
+    else:
+        d['login_url'] = "/admin/login/"
+        d['like_url'] = reverse("comments-xtd-like", args=(0,))
+        d['dislike_url'] = reverse("comments-xtd-dislike", args=(0,))
+
+    return d
+
+
+def commentbox_props_response(obj, user, request):
+    """Return a Response containing React props for use with client-side JS.
+    Can add as an extra action to a ViewSet as follows:
+
+        @action(detail=True, methods=['get'],
+                permission_classes=[permissions.IsAuthenticated])
+        def comment_props(self, request, *args, **kwargs):
+            return commentbox_props_response(self.get_object(),
+                                             request.user, request)
+    """
+    return Response(data=commentbox_props(obj, user, request=request))

--- a/django_comments_xtd/api/views.py
+++ b/django_comments_xtd/api/views.py
@@ -47,7 +47,7 @@ class CommentList(generics.ListAPIView):
             qs = XtdComment.objects.none()
         else:
             qs = XtdComment.objects.filter(content_type=content_type,
-                                           object_pk=int(object_pk_arg),
+                                           object_pk=object_pk_arg,
                                            site__pk=settings.SITE_ID,
                                            is_public=True)
         return qs
@@ -63,7 +63,7 @@ class CommentCount(generics.GenericAPIView):
         app_label, model = content_type_arg.split("-")
         content_type = ContentType.objects.get_by_natural_key(app_label, model)
         qs = XtdComment.objects.filter(content_type=content_type,
-                                       object_pk=int(object_pk_arg),
+                                       object_pk=object_pk_arg,
                                        is_public=True)
         return qs
 

--- a/django_comments_xtd/templatetags/comments_xtd.py
+++ b/django_comments_xtd/templatetags/comments_xtd.py
@@ -13,10 +13,9 @@ from django.template import (Library, Node, TemplateSyntaxError,
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
-from django_comments.forms import CommentSecurityForm
 from django_comments_xtd import get_model as get_comment_model
 from django_comments_xtd.conf import settings
-
+from django_comments_xtd.api import frontend
 
 XtdComment = get_comment_model()
 
@@ -437,60 +436,9 @@ class GetCommentBoxPropsNode(Node):
 
     def render(self, context):
         obj = self.obj.resolve(context)
-        form = CommentSecurityForm(obj)
-        ctype = ContentType.objects.get_for_model(obj)
-        queryset = XtdComment.objects.filter(content_type=ctype,
-                                             object_pk=obj.pk,
-                                             site__pk=settings.SITE_ID,
-                                             is_public=True)
-        ctype_slug = "%s-%s" % (ctype.app_label, ctype.model)
-        d = {
-            "comment_count": queryset.count(),
-            "allow_comments": True,
-            "current_user": "0:Anonymous",
-            "request_name": False,
-            "request_email_address": False,
-            "is_authenticated": False,
-            "allow_flagging": False,
-            "allow_feedback": False,
-            "show_feedback": False,
-            "can_moderate": False,
-            "poll_interval": 2000,
-            "feedback_url": reverse("comments-xtd-api-feedback"),
-            "delete_url": reverse("comments-delete", args=(0,)),
-            "reply_url": reverse("comments-xtd-reply", kwargs={'cid': 0}),
-            "flag_url": reverse("comments-flag", args=(0,)),
-            "list_url": reverse('comments-xtd-api-list',
-                                kwargs={'content_type': ctype_slug,
-                                        'object_pk': obj.id}),
-            "count_url": reverse('comments-xtd-api-count',
-                                 kwargs={'content_type': ctype_slug,
-                                         'object_pk': obj.id}),
-            "send_url": reverse("comments-xtd-api-create"),
-            "form": {
-                "content_type": form['content_type'].value(),
-                "object_pk": form['object_pk'].value(),
-                "timestamp": form['timestamp'].value(),
-                "security_hash": form['security_hash'].value()
-            }
-        }
         user = context.get('user', None)
-        try:
-            user_is_authenticated = user.is_authenticated()
-        except TypeError:  # Django >= 1.11
-            user_is_authenticated = user.is_authenticated
-        if user and user_is_authenticated:
-            d['current_user'] = "%d:%s" % (
-                user.pk, settings.COMMENTS_XTD_API_USER_REPR(user))
-            d['is_authenticated'] = True
-            d['can_moderate'] = user.has_perm("django_comments.can_moderate")
-            d['request_name'] = True if not len(user.get_full_name()) else False
-            d['request_email_address'] = True if not user.email else False
-        else:
-            d['login_url'] = "/admin/login/"
-            d['like_url'] = reverse("comments-xtd-like", args=(0,))
-            d['dislike_url'] = reverse("comments-xtd-dislike", args=(0,))
-        return json.dumps(d)
+        props = frontend.commentbox_props(obj, user)
+        return json.dumps(props)
 
 
 @register.tag
@@ -498,37 +446,7 @@ def get_commentbox_props(parser, token):
     """
     Returns a JSON object with the initial props for the CommentBox component.
 
-    The returned JSON object contains the following attributes::
-        {
-            comment_count: <int>,  // Count of comments posted to the object.
-            allow_comments: <bool>,  // Whether to allow comments to this post.
-            current_user: <str as "user_id:user_name">,
-            is_authenticated: <bool>,  // Whether current_user is authenticated.
-            request_name: <bool>,  // True when auth user has no actual name.
-            request_email_address: <bool>,  // True when auth user has no email.
-            allow_flagging: false,
-            allow_feedback: false,
-            show_feedback: false,
-            can_moderate: <bool>,  // Whether current_user can moderate.
-            poll_interval: 2000, // Check for new comments every 2 seconds.
-            feedback_url: <api-url-to-send-like/dislike-feedback>,
-            delete_url: <api-url-for-moderators-to-remove-comment>,
-            login_url: settings.LOGIN_URL,
-            reply_url: <api-url-to-reply-comments>,
-            flag_url: <api-url-to-suggest-comment-removal>,
-            list_url: <api-url-to-list-comments>,
-            count_url: <api-url-to-count-comments>,
-            send_url: <api-irl-to-send-a-comment>,
-            form: {
-                content_type: <value>,
-                object_pk: <value>,
-                timestamp: <value>,
-                security_hash: <value>
-            },
-            login_url: <only_when_user_is_not_authenticated>,
-            like_url: <only_when_user_is_not_authenticated>,
-            dislike_url: <only_when_user_is_not_authenticated>
-        }
+    See api.frontend.commentbox_props for full details on the props.
     """
     try:
         tag_name, args = token.contents.split(None, 1)

--- a/django_comments_xtd/urls.py
+++ b/django_comments_xtd/urls.py
@@ -22,9 +22,9 @@ urlpatterns = [
     # API handlers.
     url(r'^api/comment/$', api.CommentCreate.as_view(),
         name='comments-xtd-api-create'),
-    url(r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[0-9]+)/$',
+    url(r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/$',
         api.CommentList.as_view(), name='comments-xtd-api-list'),
-    url(r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[0-9]+)/count/$',
+    url(r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/count/$',
         api.CommentCount.as_view(), name='comments-xtd-api-count'),
     url(r'^api/feedback/$', api.ToggleFeedbackFlag.as_view(),
         name='comments-xtd-api-feedback'),

--- a/docs/javascript.rst
+++ b/docs/javascript.rst
@@ -140,6 +140,7 @@ The application entry point is located inside the ``index.js`` file. The ``props
 
 And are overriden by those declared in the ``var window.comments_props_override``.
 
+To use without the template, you can set up an endpoint to get the props by generating a view action within the :doc:`webapi`.
 
 Improvements and contributions
 ==============================

--- a/docs/webapi.rst
+++ b/docs/webapi.rst
@@ -13,6 +13,8 @@ There are 5 methods available to perform the following actions:
  #. Retrieve the number of comments posted to a given content type and object ID.
  #. Post user's like/dislike feedback.
  #. Post user's removal suggestions.
+ 
+Finally there is the ability to generate a view action in ``django_comments_xtd.api.frontend`` to return the commentbox props as used by the :doc:`javascript` plugin for use with an existing `django-rest-framework <http://www.django-rest-framework.org/>`_ project.
 
 .. contents:: Table of Contents
    :depth: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "django-comments-xtd"
+version = "2.3.1"
+description = "Django Comments Framework extension app with thread support, follow up notifications and email confirmations."
+authors = ["Daniel Rus Morales <mbox@danir.us>"]
+
+[tool.poetry.dependencies]
+python = "^3.4.0 || ~2.7.0"
+django-contrib-comments = "^1.8.0"
+djangorestframework = "^3.6.0"
+six = "^1.12.0"
+Django = "^2.0.0 || ~1.11.0"
+docutils = "^0.14.0"
+django-markdown2 = "^0.3.1"
+
+[tool.poetry.dev-dependencies]
+coverage = "^4.5.0"
+mock = "^2.0.0"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Hi there,

This PR makes `django-comments-xtd` easier to use with existing API-only django projects,
 * adds support for non-int based object_pk, for instead when using UUIDs or HashIds as the primary key on a model (closes #112 )
 * refactors the commentbox props generation into a separate function so can be used from the webapi for use with rest_framework/API-only backends that don't make use of server-side templates
 * adds a pyproject.yaml for use with `poetry` (https://poetry.eustace.io) and new pip environments (PEP 518)

This is quite a invasive change so happy to take feedback / make changes to get it upstreamed! :)
