### PR TITLE
Add Django 3.0 compatibility 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
  - DJANGO="2.0"
  - DJANGO="2.1"
  - DJANGO="2.2"
+ - DJANGO="3.0"
 
 before_install:
  - sudo apt-get update -qq

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ django-comments-xtd |TravisCI|_
 A Django pluggable application that adds comments to your project.
 
 .. image:: https://github.com/danirus/django-comments-xtd/blob/master/docs/images/cover.png
-  
+
 It extends the once official `django-contrib-comments <https://pypi.python.org/pypi/django-contrib-comments>`_ with the following features:
 
 #. Thread support, so comments can be nested.
@@ -23,14 +23,14 @@ It extends the once official `django-contrib-comments <https://pypi.python.org/p
 
 Example sites and tests work under officially Django `supported versions <https://www.djangoproject.com/download/#supported-versions>`_:
 
-* Django 2.1, 2.0 and 1.11
+* Django 3.0, 2.2, 2.1, 2.0 and 1.11
 * Python 3.6, 3.5, 3.4, 3.2 and 2.7
 
 Additional Dependencies:
 
 * django-contrib-comments >=1.8, <1.9
-* djangorestframework >=3.8, <3.9
+* djangorestframework >=3.9, <3.10
 
 Checkout the Docker image `danirus/django-comments-xtd-demo <https://hub.docker.com/r/danirus/django-comments-xtd-demo/>`_.
-  
+
 `Read The Docs <http://readthedocs.org/docs/django-comments-xtd/>`_.

--- a/django_comments_xtd/compat.py
+++ b/django_comments_xtd/compat.py
@@ -2,8 +2,8 @@
 import sys
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django.utils.importlib import import_module
+import six
 
 
 def import_by_path(dotted_path, error_prefix=''):

--- a/django_comments_xtd/signed.py
+++ b/django_comments_xtd/signed.py
@@ -43,7 +43,7 @@ import hmac
 import pickle
 import hashlib
 
-from django.utils import six
+import six
 from django_comments_xtd.conf import settings
 
 

--- a/django_comments_xtd/tests/templates/base.html
+++ b/django_comments_xtd/tests/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
   <head>
@@ -15,7 +15,7 @@
         max-width: 680px;
         padding: 0 15px;
       }
-    </style>    
+    </style>
   </head>
   <body>
     <div class="container">

--- a/example/comp/templates/base.html
+++ b/example/comp/templates/base.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 {% load comp_filters %}
 {% get_available_languages as LANGUAGES %}
 {% get_current_language as current_language %}
@@ -63,7 +63,7 @@
                 </div>
             </div>
         </div>
-        
+
         <script
             src="https://code.jquery.com/jquery-3.3.1.min.js"
             crossorigin="anonymous"></script>
@@ -74,7 +74,7 @@
         <script
             src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
             integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
-            crossorigin="anonymous"></script>        
+            crossorigin="anonymous"></script>
         <script
             type="text/javascript"
             src="{% url 'javascript-catalog' %}"></script>

--- a/example/comp/templates/django_comments_xtd/base.html
+++ b/example/comp/templates/django_comments_xtd/base.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 {% load comp_filters %}
 {% get_available_languages as LANGUAGES %}
 {% get_current_language as current_language %}

--- a/example/custom/templates/base.html
+++ b/example/custom/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
   <head>
@@ -14,7 +14,7 @@
       .post-footer, .comments {
         padding: 20px 0;
       }
-    </style>    
+    </style>
   </head>
   <body>
     <div class="container">
@@ -39,4 +39,4 @@
     </div>
   </body>
 </html>
-    
+

--- a/example/simple/templates/base.html
+++ b/example/simple/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
   <head>
@@ -14,7 +14,7 @@
       .post-footer, .comments {
         padding: 20px 0;
       }
-    </style>    
+    </style>
   </head>
   <body>
     <div class="container">

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
     py36-django111: django>=1.11,<1.12
     py36-django200: django>=2.0,<2.1
     py36-django210: django>=2.1,<2.2
-    py{27,36}-django{111,200,210,220}: djangorestframework>=3.8,<3.9
+    py{27,36}-django{111,200,210,220}: djangorestframework>=3.9
     py27-django111: django-contrib-comments
     py36-django{111,200,210,220}: django-contrib-comments
     py27: mock

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,7 @@ DJANGO =
   2.0: django200
   2.1: django210
   2.2: django220
-  3.0: django301
-
+  3.0: django300
 [testenv]
 changedir = {toxinidir}/django_comments_xtd
 commands = py.test -rw --cov-config .coveragerc --cov django_comments_xtd
@@ -39,11 +38,12 @@ deps =
     py36-django111: django>=1.11,<1.12
     py36-django200: django>=2.0,<2.1
     py36-django210: django>=2.1,<2.2
-    py{27,36}-django{111,200,210,220}: djangorestframework>=3.9
+    py36-django300: django>=3.0,<3.1
+    py{27,36}-django{111,200,210,220,300}: djangorestframework>=3.9
     py27-django111: django-contrib-comments
-    py36-django{111,200,210,220}: django-contrib-comments
+    py36-django{111,200,210,220,300}: django-contrib-comments
     py27: mock
-setenv = 
+setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
     DJANGO_SETTINGS_MODULE=django_comments_xtd.tests.settings
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ DJANGO =
   2.0: django200
   2.1: django210
   2.2: django220
-  3.0: django300
+  3.0: django301
 
 [testenv]
 changedir = {toxinidir}/django_comments_xtd

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ DJANGO =
   2.0: django200
   2.1: django210
   2.2: django220
+  3.0: django300
 
 [testenv]
 changedir = {toxinidir}/django_comments_xtd


### PR DESCRIPTION
Mostly removing the usage of `django.utils.six` and replacing it with a standalone `six` module.