### PR TITLE
Tutorial broken because it is incompatible with Django 3.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -34,6 +34,7 @@ Before we install any package we will set up a virtualenv and install everything
        $ cd ~/django-comments-xtd-tutorial
        $ virtualenv venv
        $ source venv/bin/activate
+       (venv)$ pip install django==2.2
        (venv)$ pip install django-comments-xtd
        (venv)$ wget https://github.com/danirus/django-comments-xtd/raw/master/example/tutorial.tar.gz
        (venv)$ tar -xvzf tutorial.tar.gz


### PR DESCRIPTION
Specifying to install Django 2.2 allows the tutorial to work.

See  https://stackoverflow.com/questions/55929472/django-templatesyntaxerror-staticfiles-is-not-a-registered-tag-library.