### PR TITLE
Closes Issue 171

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,26 @@
 # Change Log
 
+## [2.6.3] -
+
+    * Fixes issue #171, on wrong permission used to decide whether a user is a
+      moderator. The right permission is django_comments.can_moderate.
+      (thanks to Ashwani Gupta, @ashwani99)
+
 ## [2.6.2] - 2020-07-05
 
     * Adds Dutch translation (thanks to Jean-Paul Ladage, @jladage).
     * Adds Russian translation (thanks to Михаил Рыбкин, @MikerStudio).
-    * Fixes issue #140, which adds the capacity to allow only registered users
+    * Fixesissue #140, which adds the capacity to allow only registered users
       to post comments.
-    * Fixes issue #149, on wrong SQL boolean literal value used when running
+    * Fixesissue #149, on wrong SQL boolean literal value used when running
       special command populate_xtdcomments to load Postgres database with
       xtdcomments.
-    * Fixes issue #154, on using string formatting compatible with Python
+    * Fixesissue #154, on using string formatting compatible with Python
       versions prior to 3.6.
-    * Fixes issue #156, on wrong props name "poll_interval". JavaScript plugin
+    * Fixesissue #156, on wrong props name "poll_interval". JavaScript plugin
       expects uses "polling_interval" while the api/frontend.py module referred
-      to it as "poll_interval". (thanks to @ashwani99).
-    * Fixes issue #159, about using the same id for all the checkboxes in the
+      to itas "poll_interval". (thanks to @ashwani99).
+    * Fixesissue #159, about using the same id for all the checkboxes in the
       comment list. When ticking one checkbox in a nested form the checkbox of
       the main form was ticked. Now each checkbox has a different id, suffixed
       with the content of the `reply_to` field.

--- a/django_comments_xtd/api/serializers.py
+++ b/django_comments_xtd/api/serializers.py
@@ -244,7 +244,7 @@ class ReadCommentSerializer(serializers.ModelSerializer):
 
     def get_user_moderator(self, obj):
         try:
-            if obj.user and obj.user.has_perm('comments.can_moderate'):
+            if obj.user and obj.user.has_perm('django_comments.can_moderate'):
                 return True
             else:
                 return False

--- a/django_comments_xtd/api/serializers.py
+++ b/django_comments_xtd/api/serializers.py
@@ -47,8 +47,8 @@ class WriteCommentSerializer(serializers.Serializer):
     def validate_name(self, value):
         if not len(value):
             if (
-                    not len(self.request.user.get_full_name())
-                    or not self.request.user.is_authenticated
+                not len(self.request.user.get_full_name())
+                or not self.request.user.is_authenticated
             ):
                 raise serializers.ValidationError("This field is required")
             else:
@@ -59,8 +59,8 @@ class WriteCommentSerializer(serializers.Serializer):
     def validate_email(self, value):
         if not len(value):
             if (
-                    not len(self.request.user.email) or
-                    not self.request.user.is_authenticated
+                not len(self.request.user.email) or
+                not self.request.user.is_authenticated
             ):
                 raise serializers.ValidationError("This field is required")
             else:

--- a/django_comments_xtd/tests/test_api_views.py
+++ b/django_comments_xtd/tests/test_api_views.py
@@ -8,24 +8,13 @@ except ImportError:
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
-from django.urls import reverse
 
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from django_comments_xtd import django_comments
 from django_comments_xtd.api.views import CommentCreate
 from django_comments_xtd.tests.models import Article, Diary
-
-
-request_factory = APIRequestFactory()
-
-
-def post_comment(data, auth_user=None):
-    request = request_factory.post(reverse('comments-xtd-api-create'), data)
-    if auth_user:
-        force_authenticate(request, user=auth_user)
-    view = CommentCreate.as_view()
-    return view(request)
+from django_comments_xtd.tests.utils import post_comment
 
 
 app_model_options_mock = {
@@ -79,4 +68,3 @@ class CommentCreateTestCase(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.rendered_content, b'"User not authenticated"')
         self.assertEqual(self.mock_mailer.call_count, 0)
-

--- a/django_comments_xtd/tests/test_serializers.py
+++ b/django_comments_xtd/tests/test_serializers.py
@@ -1,0 +1,67 @@
+from __future__ import unicode_literals
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from django.contrib.auth.models import Permission, User
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from django_comments_xtd import django_comments
+from django_comments_xtd.api.serializers import ReadCommentSerializer
+from django_comments_xtd.models import XtdComment
+from django_comments_xtd.tests.models import Article
+from django_comments_xtd.tests.utils import post_comment
+
+
+class UserModeratorTestCase(TestCase):
+    # Test ReadCommentSerializer.user_moderator field.
+
+    def setUp(self):
+        patcher = patch('django_comments_xtd.views.send_mail')
+        self.mock_mailer = patcher.start()
+        self.article = Article.objects.create(
+            title="October", slug="october", body="What I did on October...")
+        self.form = django_comments.get_form()(self.article)
+
+    def _create_user(self, can_moderate=False):
+        bob = User.objects.create_user("joe", "fulanito@detal.com", "pwd",
+                                       first_name="Joe", last_name="Bloggs")
+        if can_moderate:
+            ct = ContentType.objects.get(app_label="django_comments",
+                                         model="comment")
+            permission = Permission.objects.get(content_type=ct,
+                                                codename="can_moderate")
+            bob.user_permissions.add(permission)
+        return bob
+
+    def _send_auth_comment(self, user):
+        data = {"name": "", "email": "",
+                "followup": True, "reply_to": 0, "level": 1, "order": 1,
+                "comment": "Es war einmal eine kleine...",
+                "honeypot": ""}
+        data.update(self.form.initial)
+        response = post_comment(data, auth_user=user)
+        self.assertEqual(response.status_code, 201)
+
+    def test_user_moderator_is_False(self):
+        bob = self._create_user(can_moderate=False)
+        self._send_auth_comment(bob)
+
+        # Fetch the comment, serialize it and check user_moderator field.
+        xtdcomment = XtdComment.objects.get(pk=1)
+        context = {"request": {"user": bob}}
+        ser = ReadCommentSerializer(xtdcomment, context=context)
+        self.assertFalse(ser.data['user_moderator'])
+
+    def test_user_moderator_is_True(self):
+        bob = self._create_user(can_moderate=True)
+        self._send_auth_comment(bob)
+
+        # Fetch the comment, serialize it and check user_moderator field.
+        xtdcomment = XtdComment.objects.get(pk=1)
+        context = {"request": {"user": bob}}
+        ser = ReadCommentSerializer(xtdcomment, context=context)
+        self.assertTrue(ser.data['user_moderator'])

--- a/django_comments_xtd/tests/utils.py
+++ b/django_comments_xtd/tests/utils.py
@@ -1,0 +1,16 @@
+from django.urls import reverse
+
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from django_comments_xtd.api.views import CommentCreate
+
+
+request_factory = APIRequestFactory()
+
+
+def post_comment(data, auth_user=None):
+    request = request_factory.post(reverse('comments-xtd-api-create'), data)
+    if auth_user:
+        force_authenticate(request, user=auth_user)
+    view = CommentCreate.as_view()
+    return view(request)

--- a/docs/webapi.rst
+++ b/docs/webapi.rst
@@ -70,26 +70,23 @@ This method retrieves the list of comments posted to a given content type and ob
            {
                "allow_reply": true,
                "comment": "Integer erat leo, ...",
-               "flags": {
-                   "dislike": {
-                       "active": false,
-                       "users": []
+               "flags": [
+                   {
+                       "flag": "like",
+                       "id": 1,
+                       "user": "admin"
                    },
-                   "like": {
-                       "active": false,
-                       "users": [
-                           "1:admin",
-                           "5:alice",
-                           "2:fulanito",
-                           "4:joebloggs",
-                           "3:menganito"
-                       ]
+                   {
+                       "flag": "like",
+                       "id": 2,
+                       "user": "fulanito"
                    },
-                   "removal": {
-                       "active": false,
-                       "count": null
+                   {
+                       "flag": "removal",
+                       "id": 2,
+                       "user": "fulanito"
                    }
-               },
+               ],
                "id": 10,
                "is_removed": false,
                "level": 0,


### PR DESCRIPTION
The permission checked was not the correct one. It had to be `django_comments.can_moderate`.
In order to allow non-superusers to moderate, they have to have the `django_comments.can_moderate` permission.