### PR TITLE
Close issue 155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Change Log
 
-## [2.6.3] -
+## [2.7.0] - 
 
+    * Fixes issue #155 (and #170), on how to post comments via the web API. Up
+      until version 2.6.2 posting comments required the fields timestamp,
+      security_hash and honeypot. As of 2.7.0 there is support to allow
+      Django REST Framework authentication classes: WriteCommentSerializer
+      send the signal should_request_be_authorize that enables posting comments.
+      Read the documentation about the web API.
     * Fixes issue #171, on wrong permission used to decide whether a user is a
       moderator. The right permission is django_comments.can_moderate.
       (thanks to Ashwani Gupta, @ashwani99)

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011, Daniel Rus Morales
+Copyright (c) 2020, Daniel Rus Morales
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -12,7 +12,7 @@ modification, are permitted provided that the following conditions are met:
   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE˝
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
 FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL

--- a/django_comments_xtd/api/serializers.py
+++ b/django_comments_xtd/api/serializers.py
@@ -12,15 +12,17 @@ from django.utils.html import escape
 from django.utils.translation import ugettext as _, activate, get_language
 
 from django_comments import get_form
+from django_comments.forms import CommentSecurityForm
 from django_comments.models import CommentFlag
 from django_comments.signals import comment_will_be_posted, comment_was_posted
-from rest_framework import serializers
+from rest_framework import exceptions, serializers
 
-from django_comments_xtd import signed, views
+from django_comments_xtd import signals, signed, views
 from django_comments_xtd.conf import settings
 from django_comments_xtd.models import (TmpXtdComment, XtdComment,
                                         LIKEDIT_FLAG, DISLIKEDIT_FLAG)
-from django_comments_xtd.signals import confirmation_received
+from django_comments_xtd.signals import (should_request_be_authorized,
+                                         confirmation_received)
 from django_comments_xtd.utils import get_app_model_options
 
 
@@ -30,8 +32,8 @@ COMMENT_MAX_LENGTH = getattr(settings, 'COMMENT_MAX_LENGTH', 3000)
 class WriteCommentSerializer(serializers.Serializer):
     content_type = serializers.CharField()
     object_pk = serializers.CharField()
-    timestamp = serializers.CharField()
-    security_hash = serializers.CharField()
+    timestamp = serializers.CharField(allow_blank=True)
+    security_hash = serializers.CharField(allow_blank=True)
     honeypot = serializers.CharField(allow_blank=True)
     name = serializers.CharField(allow_blank=True)
     email = serializers.EmailField(allow_blank=True)
@@ -93,13 +95,29 @@ class WriteCommentSerializer(serializers.Serializer):
             if whocan == "users" and not self.request.user.is_authenticated:
                 raise serializers.ValidationError("User not authenticated")
 
+        # Signal that the request allows to be authorized.
+        responses = should_request_be_authorized.send(
+            sender=target.__class__,
+            comment=target,
+            request=self.request
+        )
+
+        for (receiver, response) in responses:
+            if response is True:
+                # A positive response indicates that the POST request
+                # must be trusted. So inject the CommentSecurityForm values
+                # to pass the form validation step.
+                secform = CommentSecurityForm(target)
+                data.update({
+                    "timestamp": secform['timestamp'].value(),
+                    "security_hash": secform['security_hash'].value()
+                })
+                break
         self.form = get_form()(target, data=data)
 
-        # Check security information
+        # Check security information.
         if self.form.security_errors():
-            raise serializers.ValidationError(
-                "The comment form failed security verification: %s" %
-                escape(str(self.form.security_errors())))
+            raise exceptions.PermissionDenied()
         if self.form.errors:
             raise serializers.ValidationError(self.form.errors)
         return data
@@ -132,8 +150,8 @@ class WriteCommentSerializer(serializers.Serializer):
 
         # Replicate logic from django_comments_xtd.views.on_comment_was_posted.
         if (
-                not settings.COMMENTS_XTD_CONFIRM_EMAIL or
-                self.request.user.is_authenticated
+            not settings.COMMENTS_XTD_CONFIRM_EMAIL or
+            self.request.user.is_authenticated
         ):
             if not views._comment_exists(resp['comment']):
                 new_comment = views._create_comment(resp['comment'])

--- a/django_comments_xtd/api/serializers.py
+++ b/django_comments_xtd/api/serializers.py
@@ -32,9 +32,9 @@ COMMENT_MAX_LENGTH = getattr(settings, 'COMMENT_MAX_LENGTH', 3000)
 class WriteCommentSerializer(serializers.Serializer):
     content_type = serializers.CharField()
     object_pk = serializers.CharField()
-    timestamp = serializers.CharField(allow_blank=True)
-    security_hash = serializers.CharField(allow_blank=True)
-    honeypot = serializers.CharField(allow_blank=True)
+    timestamp = serializers.CharField(required=False)
+    security_hash = serializers.CharField(required=False)
+    honeypot = serializers.CharField(required=False)
     name = serializers.CharField(allow_blank=True)
     email = serializers.EmailField(allow_blank=True)
     url = serializers.URLField(required=False)
@@ -88,7 +88,7 @@ class WriteCommentSerializer(serializers.Serializer):
                 % (escape(ctype), escape(object_pk)))
         except (ValueError, serializers.ValidationError) as e:
             raise serializers.ValidationError(
-                "Attempting go get content-type %r and object PK %r exists "
+                "Attempting to get content-type %r and object PK %r exists "
                 "raised %s" % (escape(ctype), escape(object_pk),
                                e.__class__.__name__))
         else:
@@ -109,6 +109,7 @@ class WriteCommentSerializer(serializers.Serializer):
                 # to pass the form validation step.
                 secform = CommentSecurityForm(target)
                 data.update({
+                    "honeypot": "",
                     "timestamp": secform['timestamp'].value(),
                     "security_hash": secform['security_hash'].value()
                 })

--- a/django_comments_xtd/signals.py
+++ b/django_comments_xtd/signals.py
@@ -9,5 +9,9 @@ confirmation_received = Signal(providing_args=["comment", "request"])
 # Sent just after a user has muted a comments thread.
 comment_thread_muted = Signal(providing_args=["comment", "request"])
 
-
+# Sent before the data in the REST POST comment form is validated.
+# A receiver returning True will suffice to automatically add valid values
+# to the CommentSecurityForm fields 'timestamp' and 'security_hash'. The
+# intention is to combine a receiver with a django-rest-framework
+# authentication class, and return True when the request.auth is not None.
 should_request_be_authorized = Signal(providing_args=["comment", "request"])

--- a/django_comments_xtd/signals.py
+++ b/django_comments_xtd/signals.py
@@ -7,4 +7,7 @@ from django.dispatch import Signal
 confirmation_received = Signal(providing_args=["comment", "request"])
 
 # Sent just after a user has muted a comments thread.
-comment_thread_muted = Signal(providing_args=["comment", "requests"])
+comment_thread_muted = Signal(providing_args=["comment", "request"])
+
+
+should_request_be_authorized = Signal(providing_args=["comment", "request"])

--- a/django_comments_xtd/tests/apiauth.py
+++ b/django_comments_xtd/tests/apiauth.py
@@ -1,0 +1,30 @@
+from django.contrib.auth.models import AnonymousUser
+
+from rest_framework import HTTP_HEADER_ENCODING, authentication, exceptions
+
+
+class APIRequestAuthentication(authentication.BaseAuthentication):
+  def authenticate(self, request):
+    auth = request.META.get('HTTP_AUTHORIZATION', b'')
+    if isinstance(auth, str):
+      auth = auth.encode(HTTP_HEADER_ENCODING)
+
+    pieces = auth.split()
+    if not pieces or pieces[0].lower() != b'token':
+      return None
+
+    if len(pieces) == 1:
+      msg = _("Invalid token header. No credentials provided.")
+      raise exceptions.AuthenticationFailed(msg)
+    elif len(pieces) > 2:
+      msg = _("Invalid token header."
+          "Token string should not contain spaces.")
+      raise exceptions.AuthenticationFailed(msg)
+
+    try:
+      auth = pieces[1].decode()
+    except UnicodeError:
+      msg = _("Invalid token header. "
+          "Token string should not contain invalid characters.")
+
+    return (AnonymousUser(), auth)

--- a/django_comments_xtd/tests/models.py
+++ b/django_comments_xtd/tests/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from django.db import models
 from django.urls import reverse
 
+from django_comments_xtd.conf import settings
 from django_comments_xtd.moderation import moderator, XtdCommentModerator
 
 
@@ -59,3 +60,13 @@ class DiaryCommentModerator(XtdCommentModerator):
 
 
 moderator.register(Diary, DiaryCommentModerator)
+
+
+def authorize_api_post_comment(sender, comment, request, **kwargs):
+    if (
+        (request.user and request.user.is_authenticated) or
+        (request.auth and request.auth == settings.MY_DRF_AUTH_TOKEN)
+    ):
+        return True
+    else:
+        return False

--- a/django_comments_xtd/tests/settings.py
+++ b/django_comments_xtd/tests/settings.py
@@ -103,6 +103,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.staticfiles',
+    'rest_framework',
+
     'django_comments_xtd',
     'django_comments_xtd.tests',
     django_comments,
@@ -124,5 +126,13 @@ COMMENTS_XTD_APP_MODEL_OPTIONS = {
     }
 }
 
+MY_DRF_AUTH_TOKEN = "08d9fd42468aebbb8087b604b526ff0821ce4525"
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
+        'django_comments_xtd.tests.apiauth.APIRequestAuthentication'
+   ]
+}
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'

--- a/django_comments_xtd/tests/test_serializers.py
+++ b/django_comments_xtd/tests/test_serializers.py
@@ -8,11 +8,17 @@ except ImportError:
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
+from django.urls import reverse
+
+from rest_framework.test import APIClient
 
 from django_comments_xtd import django_comments
 from django_comments_xtd.api.serializers import ReadCommentSerializer
 from django_comments_xtd.models import XtdComment
-from django_comments_xtd.tests.models import Article
+from django_comments_xtd.signals import should_request_be_authorized
+from django_comments_xtd.tests.models import (
+    Article, authorize_api_post_comment
+)
 from django_comments_xtd.tests.utils import post_comment
 
 
@@ -65,3 +71,70 @@ class UserModeratorTestCase(TestCase):
         context = {"request": {"user": bob}}
         ser = ReadCommentSerializer(xtdcomment, context=context)
         self.assertTrue(ser.data['user_moderator'])
+
+
+class PostCommentAsVisitorTestCase(TestCase):
+    # Test WriteCommentSerializer as a mere visitor. The function in 
+    # authorize_api_post_comment in `test/models.py` is not listening for 
+    # the signal `should_request_be_authorized` yet. Therefore before
+    # connecting the signal with the function the post comment must fail
+    # indicating missing fields (timestamp, security_hash and honeypot).
+
+    def setUp(self):
+        patcher = patch('django_comments_xtd.views.send_mail')
+        self.mock_mailer = patcher.start()
+        self.article = Article.objects.create(
+            title="October", slug="october", body="What I did on October...")
+        self.form = django_comments.get_form()(self.article)
+        # Remove the following fields on purpose, as we don't know them and
+        # therefore we don't send them when using the web API (unless when)
+        # using the JavaScript plugin, but that is not the case being tested 
+        # here.
+        for field_name in ['security_hash', 'timestamp']:
+            self.form.initial.pop(field_name)
+
+    def test_post_comment_as_visitor_before_connecting_signal(self):
+        data = {
+            "name": "Joe Bloggs", "email": "joe@bloggs.com", "followup": True, 
+            "reply_to": 0, "comment": "This post comment request should fail"
+        }
+        data.update(self.form.initial)
+        response = post_comment(data)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.rendered_content, 
+            b'{"detail":"You do not have permission to perform this action."}'
+        )
+        self.assertTrue(self.mock_mailer.call_count == 0)
+
+    def test_post_comment_as_visitor_after_connecting_signal(self):
+        should_request_be_authorized.connect(authorize_api_post_comment)
+        data = {
+            "name": "Joe Bloggs", "email": "joe@bloggs.com", "followup": True, 
+            "reply_to": 0, "comment": "This post comment request should fail"
+        }
+        data.update(self.form.initial)
+        client = APIClient()
+        token = "Token 08d9fd42468aebbb8087b604b526ff0821ce4525";
+        client.credentials(HTTP_AUTHORIZATION=token)
+        self.assertTrue(self.mock_mailer.call_count == 0)
+        response = client.post(reverse('comments-xtd-api-create'), data)
+        self.assertEqual(response.status_code, 204)  # Confirmation req sent.
+        self.assertTrue(self.mock_mailer.call_count == 1)
+
+    def test_post_comment_as_registered_user_after_connecting_signal(self):
+        bob = User.objects.create_user("joe", "fulanito@detal.com", "pwd",
+                                       first_name="Joe", last_name="Bloggs")
+
+        should_request_be_authorized.connect(authorize_api_post_comment)
+        data = {
+            "name": "Joe Bloggs", "email": "joe@bloggs.com", "followup": True, 
+            "reply_to": 0, "comment": "This post comment request should fail"
+        }
+        data.update(self.form.initial)
+        client = APIClient()
+        client.login(username='joe', password='pwd')
+        self.assertTrue(self.mock_mailer.call_count == 0)
+        response = client.post(reverse('comments-xtd-api-create'), data)
+        self.assertEqual(response.status_code, 201)  # Comment created.
+        self.assertTrue(self.mock_mailer.call_count == 0)

--- a/django_comments_xtd/tests/urls.py
+++ b/django_comments_xtd/tests/urls.py
@@ -1,18 +1,21 @@
-from django.conf.urls import include, url
 from django.contrib.auth import views as auth_views
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.urls import include, path, re_path
 
 from django_comments_xtd.tests import views
 
 urlpatterns = [
-    url(r'^accounts/login/$', auth_views.LoginView),
-    url(r'^articles/(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})/'
-        r'(?P<slug>[-\w]+)/$',
-        views.dummy_view,
-        name='article-detail'),
-    url(r'^diary/(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})/',
-        views.dummy_view,
-        name='diary-detail'),
-    url(r'^comments/', include('django_comments_xtd.urls')),
+    re_path(r'^accounts/login/$', auth_views.LoginView),
+    re_path(r'^articles/(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})/'
+            r'(?P<slug>[-\w]+)/$',
+            views.dummy_view,
+            name='article-detail'),
+    re_path(r'^diary/(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})/',
+            views.dummy_view,
+            name='diary-detail'),
+    re_path(r'^comments/', include('django_comments_xtd.urls')),
+
+    re_path(r'^api-auth/', include('rest_framework.urls',
+                                   namespace='rest_framework')),
 ]
 urlpatterns += staticfiles_urlpatterns()

--- a/docs/logic.rst
+++ b/docs/logic.rst
@@ -53,7 +53,7 @@ Following is the application control logic described in 4 actions:
      
 
 Creating the secure token for the confirmation URL
---------------------------------------------------
+==================================================
 
 The Confirmation URL sent by email to the user has a secured token with the comment. To create the token Django-comments-xtd uses the module ``signed.py`` authored by Simon Willison and provided in `Django-OpenID <http://github.com/simonw/django-openid>`_. 
 
@@ -114,7 +114,8 @@ Extending the demo site with the following code will do the job:
            plus7days = timedelta(days=7)
 	       if data["submit_date"] + plus7days < datetime.now():
 	           return False
-           signals.confirmation_received.connect(check_submit_date_is_within_last_7days)
+
+       signals.confirmation_received.connect(check_submit_date_is_within_last_7days)
     
     
        #-----------------------------------------------------

--- a/docs/logic.rst
+++ b/docs/logic.rst
@@ -90,10 +90,20 @@ Signal and receiver
 
 In addition to the `signals sent by the Django Comments Framework <https://docs.djangoproject.com/en/1.3/ref/contrib/comments/signals/>`_, django-comments-xtd sends the following signal:
 
- * **confirmation_received**: Sent when the user clicks on the confirmation link and before the ``XtdComment`` instance is created in the database.
+ * **confirmation_received**: Sent when the user clicks on the confirmation
+   link and before the ``XtdComment`` instance is created in the database.
 
- * **comment_thread_muted**: Sent when the user clicks on the mute link, in a follow-up notification.
+ * **comment_thread_muted**: Sent when the user clicks on the mute link, in a
+   follow-up notification.
 
+ * **should_request_be_authorized**: Sent before the data in the form in a web
+   API post comment request is validated. A receiver returning `True` will
+   suffice to automatically add valid values to the CommentSecurityForm_ fields
+   `timestamp` and `security_hash`. The intention is to combine a receiver with
+   a django-rest-framework authentication class, and return `True` when the
+   `request.auth` is not `None`.
+
+.. _CommentSecurityForm: https://django-contrib-comments.readthedocs.io/en/latest/forms.html?highlight=commentsecurityform#django_comments.forms.CommentSecurityForm
 
 Sample use of the ``confirmation_received`` signal
 --------------------------------------------------

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -137,7 +137,7 @@ This template gets rendered if any receiver of the signal ``confirmation_receive
 ``email_followup_comment``
 --------------------------
 
-As ``.html`` and ``.txt``, this template represents the mail message sent when there is a new comment following up the user's. It's sent to the user who posted the comment that is being commented in a thread, or that arrived before the one being sent. To receive this email the user must tick the box *Notify me of follow up comments via email*.
+As ``.html`` and ``.txt``, this template represents the mail message sent to notify that comments have been sent after yours. It's sent to the user who posted the comment in the first place, when another comment arrives in the same thread or in a not nested list of comments. To receive this email the user must tick the box *Notify me follow up comments via email*.
 
 The template expects the following objects in the context:
 

--- a/example/simple/articles/models.py
+++ b/example/simple/articles/models.py
@@ -3,8 +3,13 @@ from __future__ import unicode_literals
 
 import django
 from django.db import models
+from django.dispatch import receiver
 from django.urls import reverse
 from django.utils import timezone
+
+from django_comments_xtd.conf import settings
+from django_comments_xtd.signals import should_request_be_authorized
+
 
 class PublicManager(models.Manager):
     """Returns published articles that are not in the future."""
@@ -41,3 +46,12 @@ class Article(models.Model):
                     'month': int(self.publish.strftime('%m').lower()),
                     'day': self.publish.day,
                     'slug': self.slug})
+
+
+@receiver(should_request_be_authorized)
+def my_callback(sender, comment, request, **kwargs):
+    if (
+        (request.auth and request.auth == settings.MY_DRF_AUTH_TOKEN) or
+        (request.user and request.user.is_authenticated)
+    ):
+        return True

--- a/example/simple/settings.py
+++ b/example/simple/settings.py
@@ -79,18 +79,18 @@ SECRET_KEY = 'v2824l&2-n+4zznbsk9c-ap5i)b3e8b+%*a=dxqlahm^%)68jn'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-	'DIRS': [
-	    os.path.join(os.path.dirname(__file__), "templates"),
-	],
+        'DIRS': [
+            os.path.join(os.path.dirname(__file__), "templates"),
+        ],
         'APP_DIRS': True,
-	'OPTIONS': {
-	    'context_processors': [
+        'OPTIONS': {
+            'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
-		'django.contrib.auth.context_processors.auth',
+                'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-	    ],
-	},
+            ],
+        },
     },
 ]
 


### PR DESCRIPTION
This PR implements a new behaviour in the validate method of `WriteCommentSerializer`, used when posting comments via the web API. The new behaviour consist of a new signal, `should_request_be_authorized`, which must be used along with [Django REST Framework authentication classes](https://www.django-rest-framework.org/api-guide/authentication/) to authorize the request. Implements corresponding regression tests. 

Read the extended documentation about the web API (will be released with v2.7.0).