### PR TITLE
Closes issue #215

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - 3.7
+  - 3.8
 
 cache:
   pip:
@@ -14,6 +14,7 @@ env:
  - DJANGO="2.1"
  - DJANGO="2.2"
  - DJANGO="3.0"
+ - DJANGO="3.1"
 
 before_install:
  - sudo apt-get update -qq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [] - YYYY-MM-DD
+
+    * Fixes issue #215 about running the tests with Django 3.1 and Python 3.8.
+
 ## [2.7.2] - 2020-09-08
 
     * Fixes issue #208, about the JavaScript plugin not displaying the like and
@@ -13,8 +17,8 @@
     * Fixes issue #188, about loading a templatetags module not required for
       the application.
     * Fixes issue #196. When extending django-comments-xtd's comment model, the
-      receiver function that reviews whether nested comments have to be publish or
-      unpublish is not called.
+      receiver function that reviews whether nested comments have to be publish
+      or unpublish is not called.
 
 ## [2.7.0] - 2020-08-09
 

--- a/django_comments_xtd/urls.py
+++ b/django_comments_xtd/urls.py
@@ -8,7 +8,7 @@ from django_comments_xtd import api, views
 urlpatterns = [
     re_path(r'^sent/$', views.sent, name='comments-xtd-sent'),
     re_path(r'^confirm/(?P<key>[^/]+)/$', views.confirm,
-        name='comments-xtd-confirm'),
+            name='comments-xtd-confirm'),
     re_path(r'^mute/(?P<key>[^/]+)/$', views.mute, name='comments-xtd-mute'),
     re_path(r'^reply/(?P<cid>[\d]+)/$', views.reply, name='comments-xtd-reply'),
 
@@ -18,7 +18,7 @@ urlpatterns = [
     re_path(r'^like/(\d+)/$', views.like, name='comments-xtd-like'),
     re_path(r'^liked/$', views.like_done, name='comments-xtd-like-done'),
     re_path(r'^dislike/(\d+)/$', views.dislike, name='comments-xtd-dislike'),
-    re_path(r'^disliked/$', views.dislike_done, 
+    re_path(r'^disliked/$', views.dislike_done,
             name='comments-xtd-dislike-done'),
 
     # API handlers.
@@ -27,7 +27,7 @@ urlpatterns = [
     re_path(r'^api/preview/$', api.preview_user_avatar,
             name='comments-xtd-api-preview'),
     re_path(r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/$',
-        api.CommentList.as_view(), name='comments-xtd-api-list'),
+            api.CommentList.as_view(), name='comments-xtd-api-list'),
     re_path(
         r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/count/$',
         api.CommentCount.as_view(), name='comments-xtd-api-count'),

--- a/django_comments_xtd/urls.py
+++ b/django_comments_xtd/urls.py
@@ -1,39 +1,42 @@
-from django.conf.urls import include, url
+# from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from django_comments_xtd import api, views
 
 urlpatterns = [
-    url(r'^sent/$', views.sent, name='comments-xtd-sent'),
-    url(r'^confirm/(?P<key>[^/]+)/$', views.confirm,
+    re_path(r'^sent/$', views.sent, name='comments-xtd-sent'),
+    re_path(r'^confirm/(?P<key>[^/]+)/$', views.confirm,
         name='comments-xtd-confirm'),
-    url(r'^mute/(?P<key>[^/]+)/$', views.mute, name='comments-xtd-mute'),
-    url(r'^reply/(?P<cid>[\d]+)/$', views.reply, name='comments-xtd-reply'),
+    re_path(r'^mute/(?P<key>[^/]+)/$', views.mute, name='comments-xtd-mute'),
+    re_path(r'^reply/(?P<cid>[\d]+)/$', views.reply, name='comments-xtd-reply'),
 
     # Remap comments-flag to check allow-flagging is enabled.
-    url(r'^flag/(\d+)/$', views.flag, name='comments-flag'),
+    re_path(r'^flag/(\d+)/$', views.flag, name='comments-flag'),
     # New flags in addition to those provided by django-contrib-comments.
-    url(r'^like/(\d+)/$', views.like, name='comments-xtd-like'),
-    url(r'^liked/$', views.like_done, name='comments-xtd-like-done'),
-    url(r'^dislike/(\d+)/$', views.dislike, name='comments-xtd-dislike'),
-    url(r'^disliked/$', views.dislike_done, name='comments-xtd-dislike-done'),
+    re_path(r'^like/(\d+)/$', views.like, name='comments-xtd-like'),
+    re_path(r'^liked/$', views.like_done, name='comments-xtd-like-done'),
+    re_path(r'^dislike/(\d+)/$', views.dislike, name='comments-xtd-dislike'),
+    re_path(r'^disliked/$', views.dislike_done, 
+            name='comments-xtd-dislike-done'),
 
     # API handlers.
-    url(r'^api/comment/$', api.CommentCreate.as_view(),
-        name='comments-xtd-api-create'),
-    url(r'^api/preview/$', api.preview_user_avatar,
-        name='comments-xtd-api-preview'),
-    url(r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/$',
+    re_path(r'^api/comment/$', api.CommentCreate.as_view(),
+            name='comments-xtd-api-create'),
+    re_path(r'^api/preview/$', api.preview_user_avatar,
+            name='comments-xtd-api-preview'),
+    re_path(r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/$',
         api.CommentList.as_view(), name='comments-xtd-api-list'),
-    url(r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/count/$',
+    re_path(
+        r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/count/$',
         api.CommentCount.as_view(), name='comments-xtd-api-count'),
-    url(r'^api/feedback/$', api.ToggleFeedbackFlag.as_view(),
-        name='comments-xtd-api-feedback'),
-    url(r'^api/flag/$', api.CreateReportFlag.as_view(),
-        name='comments-xtd-api-flag'),
+    re_path(r'^api/feedback/$', api.ToggleFeedbackFlag.as_view(),
+            name='comments-xtd-api-feedback'),
+    re_path(r'^api/flag/$', api.CreateReportFlag.as_view(),
+            name='comments-xtd-api-flag'),
 
-    url(r'', include("django_comments.urls")),
+    re_path(r'', include("django_comments.urls")),
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,11 @@ django_find_project = false
 
 [tox]
 skipsdist = True
-envlist = py36-django{200,210,220,300}
+envlist = py38-django{200,210,220,300,310}
 
 [travis]
 python =
-  3.6: py36
+  3.8: py38
 
 [travis:env]
 DJANGO =
@@ -20,6 +20,7 @@ DJANGO =
   2.1: django210
   2.2: django220
   3.0: django300
+  3.1: django310
 [testenv]
 changedir = {toxinidir}/django_comments_xtd
 commands = py.test -rw --cov-config .coveragerc --cov django_comments_xtd
@@ -32,12 +33,13 @@ deps =
     pytest-cov
     pytest-django
     selenium
-    py36-django200: django>=2.0,<2.1
-    py36-django210: django>=2.1,<2.2
-    py36-django220: django>=2.2,<2.3
-    py36-django300: django>=3.0,<3.1
-    py36-django{200,210,220,300}: djangorestframework>=3.9
-    py36-django{200,210,220,300}: django-contrib-comments
+    py38-django200: django>=2.0,<2.1
+    py38-django210: django>=2.1,<2.2
+    py38-django220: django>=2.2,<2.3
+    py38-django300: django>=3.0,<3.1
+    py38-django310: django>=3.1,<3.2
+    py38-django{200,210,220,300,310}: djangorestframework>=3.9
+    py38-django{200,210,220,300,310}: django-contrib-comments
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
     DJANGO_SETTINGS_MODULE=django_comments_xtd.tests.settings


### PR DESCRIPTION
Adds Django 3.1 to the battery of tests run with tox.
Also, switch the python version in tox, from Python 3.6 to Python 3.8.