### PR TITLE
Issue 221

### DIFF
--- a/django_comments_xtd/__init__.py
+++ b/django_comments_xtd/__init__.py
@@ -22,9 +22,7 @@ VERSION = (2, 8, 0, 'f', 0)  # following PEP 440
 
 
 def get_version():
-    version = '%s.%s' % (VERSION[0], VERSION[1])
-    if VERSION[2] is not None:
-        version = '%s.%s' % (version, VERSION[2])
+    version = '%s.%s.%s' % (VERSION[0], VERSION[1], VERSION[2])
     if VERSION[3] != 'f':
         version = '%s%s%s' % (version, VERSION[3], VERSION[4])
     return version

--- a/django_comments_xtd/__init__.py
+++ b/django_comments_xtd/__init__.py
@@ -23,7 +23,7 @@ VERSION = (2, 8, 0, 'f', 0)  # following PEP 440
 
 def get_version():
     version = '%s.%s' % (VERSION[0], VERSION[1])
-    if VERSION[2]:
+    if VERSION[2] is not None:
         version = '%s.%s' % (version, VERSION[2])
     if VERSION[3] != 'f':
         version = '%s%s%s' % (version, VERSION[3], VERSION[4])

--- a/django_comments_xtd/tests/test_get_version.py
+++ b/django_comments_xtd/tests/test_get_version.py
@@ -1,0 +1,19 @@
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from django.test import TestCase
+
+
+class GetVersionTestCase(TestCase):
+
+    @patch('django_comments_xtd.VERSION', (2, 8, 0, 'f', 0))
+    def test_get_version_when_patch_equal_to_zero(self):
+        from django_comments_xtd import get_version
+        self.assertEqual(get_version(), '2.8.0')
+
+    @patch('django_comments_xtd.VERSION', (2, 8, 1, 'f', 0))
+    def test_get_version_when_patch_greater_than_zero(self):
+        from django_comments_xtd import get_version
+        self.assertEqual(get_version(), '2.8.1')

--- a/django_comments_xtd/tests/test_get_version.py
+++ b/django_comments_xtd/tests/test_get_version.py
@@ -17,3 +17,8 @@ class GetVersionTestCase(TestCase):
     def test_get_version_when_patch_greater_than_zero(self):
         from django_comments_xtd import get_version
         self.assertEqual(get_version(), '2.8.1')
+
+    @patch('django_comments_xtd.VERSION', (2, 8, 1, 9, 8))
+    def test_get_version_when_version_three_not_f(self):
+        from django_comments_xtd import get_version
+        self.assertEqual(get_version(), '2.8.198')


### PR DESCRIPTION
# Problem
Issue with patch versions as noted in [Issue 221](https://github.com/danirus/django-comments-xtd/issues/221) filed by @gassan 
It appears this line was never getting hit, because `0` is falsy in python (see [here](https://docs.python.org/3/library/stdtypes.html#truth-value-testing)).

# Solution
Instead of evaluating `if VERSION[2]:` I updated it to `if VERSION[2] is not None`

# Testing
I added 2 unit tests to ensure a `0` patch version and anything greater than `0` is handled.