### PR TITLE
Fixes issue #250.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Change Log
 
+## [2.8.2] -
+
+    * Fixes issue #250, which reports that using the web API to post a comment
+      with a reply_to field that would break the max_thread_level should not
+      produce an exception but rather a controlled response with an appropriate
+      HTTP code.
+
 ## [2.8.1] - 2020-10-16
 
     * Fixes issue #80, that requests to change the response when clicking
       more than once on a comment confirmation link. Up until now clicking
       more than once on a comment confirmation link produced a HTTP 404
-      response. Since version 2.8.1 the response is the same as for the first click: the user is redirected to the comment's view in the page.
+      response. Since version 2.8.1 the response is the same as for the first
+      click: the user is redirected to the comment's view in the page.
       Thanks to @ppershing.
     * Fixes issue #152, about loading the `staticfiles` templatetag instead of
       `static`. Since Django v3.0 the staticfiles app requires using the

--- a/django_comments_xtd/api/serializers.py
+++ b/django_comments_xtd/api/serializers.py
@@ -69,7 +69,7 @@ class WriteCommentSerializer(serializers.Serializer):
         if value != 0:
             try:
                 parent = get_model().objects.get(pk=value)
-            except get_model().DoesNotExist as exc:
+            except get_model().DoesNotExist:
                 raise serializers.ValidationError(
                     "reply_to comment does not exist")
             else:


### PR DESCRIPTION
This PR resolves issue 250, which reports that using the web API to post a comment with a reply_to field that would break the max_thread_level should not produce an exception but rather a controlled response with an appropriate HTTP code. 
The scenario has been added as a test to `tests/test_api_views.py`.