### PR TITLE
206 follow up checkbox customizable

### DIFF
--- a/django_comments_xtd/conf/defaults.py
+++ b/django_comments_xtd/conf/defaults.py
@@ -63,3 +63,5 @@ COMMENTS_XTD_API_USER_REPR = username
 # Rewrite this function to make the web API use a different logic.
 # Should return an URL.
 COMMENTS_XTD_API_GET_USER_AVATAR = "django_comments_xtd.utils.get_user_avatar"
+
+COMMENTS_XTD_DEFAULT_FOLLOW_UP = True

--- a/django_comments_xtd/templates/comments/form.html
+++ b/django_comments_xtd/templates/comments/form.html
@@ -55,14 +55,16 @@
         </div>
         {% endif %}
 
-        <div class="row form-group">
-            <div class="offset-md-3 col-md-7">
-                <div class="custom-control custom-checkbox">
-                    {{ form.followup }}
-                    <label for="id_followup{% if cid %}_{{ cid }}{% endif %}" class="custom-control-label">&nbsp;{{ form.followup.label }}</label>
+        {% if form.followup %}
+            <div class="row form-group">
+                <div class="offset-md-3 col-md-7">
+                    <div class="custom-control custom-checkbox">
+                        {{ form.followup }}
+                        <label for="id_followup{% if cid %}_{{ cid }}{% endif %}" class="custom-control-label">&nbsp;{{ form.followup.label }}</label>
+                    </div>
                 </div>
             </div>
-        </div>
+        {% endif %}
     </fieldset>
 
     <div class="row form-group">

--- a/django_comments_xtd/tests/test_forms.py
+++ b/django_comments_xtd/tests/test_forms.py
@@ -61,4 +61,5 @@ class XtdCommentFormTestCase(TestCase):
 
         # it does have the new field 'followup'
         self.assertTrue("followup" in comment)
+        # But we don't have it in form, it comes from the settings
         self.assertFalse('followup' in form)

--- a/django_comments_xtd/tests/test_forms.py
+++ b/django_comments_xtd/tests/test_forms.py
@@ -5,6 +5,11 @@ from django_comments_xtd.models import TmpXtdComment
 from django_comments_xtd.forms import XtdCommentForm
 from django_comments_xtd.tests.models import Article
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 
 class GetFormTestCase(TestCase):
 
@@ -40,3 +45,20 @@ class XtdCommentFormTestCase(TestCase):
 
         # it does have the new field 'followup'
         self.assertTrue("followup" in comment)
+
+    @patch.multiple('django_comments_xtd.conf.settings',
+                COMMENTS_XTD_DEFAULT_FOLLOW_UP=True)
+    def test_setting_COMMENTS_XTD_DEFAULT_FOLLOW_UP_works(self):
+                # as it's used in django_comments.views.comments
+        data = {"name": "Daniel",
+                "email": "danirus@eml.cc",
+                "followup": True,
+                "reply_to": 0, "level": 1, "order": 1,
+                "comment": "Es war einmal iene kleine..."}
+        data.update(self.form.initial)
+        form = django_comments.get_form()(self.article, data)
+        comment = form.get_comment_object()
+
+        # it does have the new field 'followup'
+        self.assertTrue("followup" in comment)
+        self.assertFalse('followup' in form)


### PR DESCRIPTION
Hello @danirus 
If I understood right - here is my suggestion regarding the new `COMMENTS_XTD_DEFAULT_FOLLOW_UP` settings. So:

1. If we have it as `True` - we won't see the follow-up field, but it'll be enabled by default
2. If we have it as `False` - we'll see the follow-up checkbox and the functionality will be the same as we have in the current version.
Does it make sense?

#206 

Best regards.