### PR TITLE
Closes #248, API must return submit_date in timezone when enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
-## [2.8.2] - 2021-01-22
+## [2.8.2] - 2021-01-24
 
+    * Fixes issue #248, about the API returning comments' submit_date in UTC
+      when the setting USE_TZ is enabled and a different TIME_ZONE is given.
     * Fixes issue #250, which reports that using the web API to post a comment
       with a reply_to field that would break the max_thread_level should not
       produce an exception but rather a controlled response with an appropriate

--- a/django_comments_xtd/api/serializers.py
+++ b/django_comments_xtd/api/serializers.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.shortcuts import get_current_site
-from django.utils import formats
+from django.utils import formats, timezone
 from django.utils.html import escape
 from django.utils.module_loading import import_string
 from django.utils.translation import ugettext as _, activate, get_language
@@ -263,7 +263,11 @@ class ReadCommentSerializer(serializers.ModelSerializer):
 
     def get_submit_date(self, obj):
         activate(get_language())
-        return formats.date_format(obj.submit_date, 'DATETIME_FORMAT',
+        if settings.USE_TZ:
+            submit_date = timezone.localtime(obj.submit_date)
+        else:
+            submit_date = obj.submit_date
+        return formats.date_format(submit_date, 'DATETIME_FORMAT',
                                    use_l10n=True)
 
     def get_comment(self, obj):

--- a/django_comments_xtd/templates/django_comments_xtd/comment_tree.html
+++ b/django_comments_xtd/templates/django_comments_xtd/comment_tree.html
@@ -1,4 +1,3 @@
-{% load l10n %}
 {% load i18n %}
 {% load comments %}
 {% load comments_xtd %}
@@ -10,7 +9,7 @@
   <div class="media-body">
     <div class="comment pb-3">
       <h6 class="mb-1 small d-flex">
-        <div class="mr-auto">{{ item.comment.submit_date|localize }}&nbsp;-&nbsp;{% if item.comment.url and not item.comment.is_removed %}<a href="{{ item.comment.url }}" target="_new">{% endif %}{{ item.comment.name }}{% if item.comment.url %}</a>{% endif %}{% if item.comment.user and item.comment.user|has_permission:"django_comments.can_moderate" %}&nbsp;<span class="badge badge-secondary">{% trans "moderator" %}</span>{% endif %}&nbsp;&nbsp;<a class="permalink" title="{% trans 'comment permalink' %}" href="{% get_comment_permalink item.comment %}">¶</a></div>
+        <div class="mr-auto">{{ item.comment.submit_date }}&nbsp;-&nbsp;{% if item.comment.url and not item.comment.is_removed %}<a href="{{ item.comment.url }}" target="_new">{% endif %}{{ item.comment.name }}{% if item.comment.url %}</a>{% endif %}{% if item.comment.user and item.comment.user|has_permission:"django_comments.can_moderate" %}&nbsp;<span class="badge badge-secondary">{% trans "moderator" %}</span>{% endif %}&nbsp;&nbsp;<a class="permalink" title="{% trans 'comment permalink' %}" href="{% get_comment_permalink item.comment %}">¶</a></div>
         <span>
           {% if not item.comment.is_removed %}
             {% if perms.comments.can_moderate %}

--- a/django_comments_xtd/tests/settings.py
+++ b/django_comments_xtd/tests/settings.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import os
 import imp
-import django
 
 
 PRJ_PATH = os.path.abspath(os.path.curdir)
@@ -32,6 +31,8 @@ DATABASES = {
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
 TIME_ZONE = 'Europe/Berlin'
+USE_TZ = False
+USE_L10N = False
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
@@ -67,8 +68,9 @@ ADMIN_MEDIA_PREFIX = '/media/'
 SECRET_KEY = 'v2824l&2-n+4zznbsk9c-ap5i)b3e8b+%*a=dxqlahm^%)68jn'
 
 MIDDLEWARE = [
-    'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
+    'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
 ]
 

--- a/django_comments_xtd/tests/test_serializers.py
+++ b/django_comments_xtd/tests/test_serializers.py
@@ -196,11 +196,6 @@ class ReadCommentsGetUserAvatarTestCase(TestCase):
 
 
 class RenderSubmitDateTestCase(TestCase):
-    # Test that the submit_date returned by the ReadCommentSerializer matches
-    # that one rendered with render_comment_list. The serializer is used to
-    # feed the JavaScript plugin, therefore the submit_date in the serializer
-    # can be considered as a rendered date.
-
     def setUp(self):
         self.article = Article.objects.create(title="October", slug="october",
                                               body="What I did on October...")

--- a/django_comments_xtd/tests/test_serializers.py
+++ b/django_comments_xtd/tests/test_serializers.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from datetime import datetime
+import pytz
 try:
     from unittest.mock import patch
 except ImportError:
@@ -76,8 +77,8 @@ class UserModeratorTestCase(TestCase):
 
 
 class PostCommentAsVisitorTestCase(TestCase):
-    # Test WriteCommentSerializer as a mere visitor. The function in 
-    # authorize_api_post_comment in `test/models.py` is not listening for 
+    # Test WriteCommentSerializer as a mere visitor. The function in
+    # authorize_api_post_comment in `test/models.py` is not listening for
     # the signal `should_request_be_authorized` yet. Therefore before
     # connecting the signal with the function the post comment must fail
     # indicating missing fields (timestamp, security_hash and honeypot).
@@ -90,21 +91,21 @@ class PostCommentAsVisitorTestCase(TestCase):
         self.form = django_comments.get_form()(self.article)
         # Remove the following fields on purpose, as we don't know them and
         # therefore we don't send them when using the web API (unless when)
-        # using the JavaScript plugin, but that is not the case being tested 
+        # using the JavaScript plugin, but that is not the case being tested
         # here.
         for field_name in ['security_hash', 'timestamp']:
             self.form.initial.pop(field_name)
 
     def test_post_comment_as_visitor_before_connecting_signal(self):
         data = {
-            "name": "Joe Bloggs", "email": "joe@bloggs.com", "followup": True, 
+            "name": "Joe Bloggs", "email": "joe@bloggs.com", "followup": True,
             "reply_to": 0, "comment": "This post comment request should fail"
         }
         data.update(self.form.initial)
         response = post_comment(data)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(
-            response.rendered_content, 
+            response.rendered_content,
             b'{"detail":"You do not have permission to perform this action."}'
         )
         self.assertTrue(self.mock_mailer.call_count == 0)
@@ -112,7 +113,7 @@ class PostCommentAsVisitorTestCase(TestCase):
     def test_post_comment_as_visitor_after_connecting_signal(self):
         should_request_be_authorized.connect(authorize_api_post_comment)
         data = {
-            "name": "Joe Bloggs", "email": "joe@bloggs.com", "followup": True, 
+            "name": "Joe Bloggs", "email": "joe@bloggs.com", "followup": True,
             "reply_to": 0, "comment": "This post comment request should fail"
         }
         data.update(self.form.initial)
@@ -130,7 +131,7 @@ class PostCommentAsVisitorTestCase(TestCase):
 
         should_request_be_authorized.connect(authorize_api_post_comment)
         data = {
-            "name": "Joe Bloggs", "email": "joe@bloggs.com", "followup": True, 
+            "name": "Joe Bloggs", "email": "joe@bloggs.com", "followup": True,
             "reply_to": 0, "comment": "This post comment request should fail"
         }
         data.update(self.form.initial)
@@ -152,7 +153,7 @@ funcpath = "django_comments_xtd.tests.test_serializers.get_fake_avatar"
 class ReadCommentsGetUserAvatarTestCase(TestCase):
     # Test ReadCommentSerializer method get_user_avatar.
     # Change setting COMMENTS_XTD_API_GET_USER_AVATAR so that it uses a
-    # deterministic function: get_fake_avatar (here defined). Then send a 
+    # deterministic function: get_fake_avatar (here defined). Then send a
     # couple of comments and verify that the function is called.
 
     def setUp(self):
@@ -160,8 +161,8 @@ class ReadCommentsGetUserAvatarTestCase(TestCase):
                                        first_name="Joe", last_name="Bloggs")
         alice = User.objects.create_user("alice", "alice@tal.com", "alicepwd",
                                          first_name="Alice", last_name="Bloggs")
-        self.article = Article.objects.create(title="September", 
-                                              slug="september", 
+        self.article = Article.objects.create(title="September",
+                                              slug="september",
                                               body="During September...")
         self.article_ct = ContentType.objects.get(app_label="tests",
                                                   model="article")
@@ -192,3 +193,48 @@ class ReadCommentsGetUserAvatarTestCase(TestCase):
         ser = ReadCommentSerializer(qs, context={"request": None}, many=True)
         self.assertEqual(ser.data[0]['user_avatar'], '/fake/avatar/joe')
         self.assertEqual(ser.data[1]['user_avatar'], '/fake/avatar/alice')
+
+
+class RenderSubmitDateTestCase(TestCase):
+    # Test that the submit_date returned by the ReadCommentSerializer matches
+    # that one rendered with render_comment_list. The serializer is used to
+    # feed the JavaScript plugin, therefore the submit_date in the serializer
+    # can be considered as a rendered date.
+
+    def setUp(self):
+        self.article = Article.objects.create(title="October", slug="october",
+                                              body="What I did on October...")
+
+    def create_comment(self, submit_date_is_aware=True):
+        site = Site.objects.get(pk=1)
+        ctype = ContentType.objects.get(app_label="tests", model="article")
+        if submit_date_is_aware:
+            utc = pytz.timezone("UTC")
+            submit_date = datetime(2021, 1, 10, 10, 15, tzinfo=utc)
+        else:
+            submit_date = datetime(2021, 1, 10, 10, 15)
+        self.cm = XtdComment.objects.create(content_type=ctype,
+                                            object_pk=self.article.id,
+                                            content_object=self.article,
+                                            site=site, name="Joe Bloggs",
+                                            email="joe@bloggs.com",
+                                            comment="Just a comment",
+                                            submit_date=submit_date)
+
+    @patch.multiple('django.conf.settings', USE_TZ=False)
+    @patch.multiple('django_comments_xtd.conf.settings', USE_TZ=False)
+    def test_submit_date_when_use_tz_is_false(self):
+        self.create_comment(submit_date_is_aware=False)
+        qs = XtdComment.objects.all()
+        ser = ReadCommentSerializer(qs, context={"request": None}, many=True)
+        self.assertEqual(ser.data[0]['submit_date'],
+                         'Jan. 10, 2021, 10:15 a.m.')
+
+    @patch.multiple('django.conf.settings', USE_TZ=True)
+    @patch.multiple('django_comments_xtd.conf.settings', USE_TZ=True)
+    def test_submit_date_when_use_tz_is_true(self):
+        self.create_comment(submit_date_is_aware=True)
+        qs = XtdComment.objects.all()
+        ser = ReadCommentSerializer(qs, context={"request": None}, many=True)
+        self.assertEqual(ser.data[0]['submit_date'],
+                         'Jan. 10, 2021, 11:15 a.m.')

--- a/example/comp/settings.py
+++ b/example/comp/settings.py
@@ -1,7 +1,6 @@
 #-*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import django
 import os
 
 
@@ -37,6 +36,7 @@ DATABASES = {
 # system time zone.
 TIME_ZONE = 'Europe/Berlin'
 USE_TZ = True
+USE_L10N = True
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html

--- a/example/comp/templates/django_comments_xtd/comment_tree.html
+++ b/example/comp/templates/django_comments_xtd/comment_tree.html
@@ -1,4 +1,3 @@
-{% load l10n %}
 {% load i18n %}
 {% load comments %}
 {% load comments_xtd %}
@@ -11,7 +10,7 @@
   <div class="media-body">
     <div class="comment pb-3">
       <h6 class="mb-1 small d-flex">
-        <div class="mr-auto">{{ item.comment.submit_date|localize }}&nbsp;-&nbsp;{% if item.comment.url and not item.comment.is_removed %}<a href="{{ item.comment.url }}" target="_new">{% endif %}{{ item.comment.name }}{% if item.comment.url %}</a>{% endif %}{% if item.comment.user and item.comment.user|has_permission:"django_comments.can_moderate" %}&nbsp;<span class="badge badge-secondary">{% trans "moderator" %}</span>{% endif %}&nbsp;&nbsp;<a class="permalink" title="{% trans 'comment permalink' %}" href="{% get_comment_permalink item.comment %}">¶</a></div>
+        <div class="mr-auto">{{ item.comment.submit_date }}&nbsp;-&nbsp;{% if item.comment.url and not item.comment.is_removed %}<a href="{{ item.comment.url }}" target="_new">{% endif %}{{ item.comment.name }}{% if item.comment.url %}</a>{% endif %}{% if item.comment.user and item.comment.user|has_permission:"django_comments.can_moderate" %}&nbsp;<span class="badge badge-secondary">{% trans "moderator" %}</span>{% endif %}&nbsp;&nbsp;<a class="permalink" title="{% trans 'comment permalink' %}" href="{% get_comment_permalink item.comment %}">¶</a></div>
         <span>
           {% if not item.comment.is_removed %}
             {% if perms.comments.can_moderate %}

--- a/example/simple/settings.py
+++ b/example/simple/settings.py
@@ -123,8 +123,8 @@ INSTALLED_APPS = (
 )
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
-    
-# EMAIL_HOST          = "smtp.gmail.com" 
+
+# EMAIL_HOST          = "smtp.gmail.com"
 # EMAIL_PORT          = "587"
 # EMAIL_HOST_USER     = "username@gmail.com"
 # EMAIL_HOST_PASSWORD = ""
@@ -132,7 +132,7 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 # DEFAULT_FROM_EMAIL  = "Alice Bloggs <alice@example.com>"
 # SERVER_EMAIL        = DEFAULT_FROM_EMAIL
 
-# Fill in actual EMAIL settings above, and comment out the 
+# Fill in actual EMAIL settings above, and comment out the
 # following line to let this django demo sending emails
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 


### PR DESCRIPTION
In this PR the serializer `ReadCommentSerializer` has been modified to return the `submit_date` corresponding to the timezone active in the settings. When `USE_TZ` is not active `submit_date` will be UTC based.