### PR TITLE
Customize operation ids

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        django: ["2.0", "2.1", "2.2", "3.0", "3.1"]
+        django: ["2.2", "3.0", "3.1"]
     steps:
       - uses: actions/checkout@v2
       - name: Python setup

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Example sites and tests work under officially Django `supported versions <https:
 Additional Dependencies:
 
 * django-contrib-comments >=1.8
-* djangorestframework >=3.9
+* djangorestframework >=3.12
 
 Checkout the Docker image `danirus/django-comments-xtd-demo <https://hub.docker.com/r/danirus/django-comments-xtd-demo/>`_.
 

--- a/django_comments_xtd/api/views.py
+++ b/django_comments_xtd/api/views.py
@@ -9,6 +9,7 @@ from django_comments.views.moderation import perform_flag
 from rest_framework import generics, mixins, permissions, status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from rest_framework.schemas.openapi import AutoSchema
 
 from django_comments_xtd import views
 from django_comments_xtd.conf import settings
@@ -99,6 +100,8 @@ class ToggleFeedbackFlag(generics.CreateAPIView, mixins.DestroyModelMixin):
     serializer_class = serializers.FlagSerializer
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
 
+    schema = AutoSchema(operation_id_base="Feedback")
+
     def post(self, request, *args, **kwargs):
         response = super(ToggleFeedbackFlag, self).post(request, *args,
                                                         **kwargs)
@@ -117,6 +120,8 @@ class CreateReportFlag(generics.CreateAPIView):
 
     serializer_class = serializers.FlagSerializer
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
+
+    schema = AutoSchema(operation_id_base="ReportFlag")
 
     def post(self, request, *args, **kwargs):
         return super(CreateReportFlag, self).post(request, *args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Daniel Rus Morales <mbox@danir.us>"]
 [tool.poetry.dependencies]
 python = "^3.4.0"
 django-contrib-comments = "^1.8.0"
-djangorestframework = "^3.6.0"
+djangorestframework = "^3.12.0"
 six = "^1.12.0"
 Django = "^2.0.0"
 docutils = "^0.14.0"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         'Django>=2.2',
         'django-contrib-comments>=1.9',
-        'djangorestframework>=3.9',
+        'djangorestframework>=3.12',
         'docutils',
         'six',
     ],


### PR DESCRIPTION
Using standard REST Framework tools to generate OpenAPI schema leads to the warning

```
$ ./manage.py generateschema > openapi-schema.yml
/Users/sergeyivanychev/.local/share/virtualenvs/school-project-rI8dYCXm/lib/python3.9/site-packages/rest_framework/schemas/openapi.py:49: UserWarning: You have a duplicated operationId in your OpenAPI schema: createFlag
        Route: /comments/api/feedback/, Method: post
        Route: /comments/api/flag/, Method: post
        An operationId has to be unique across your schema. Your schema may not work in other tools.
```

This is caused by two similar API views with the same model names. This PR specifies different suffixes for the generated operation IDs so that there's no naming conflict.