### PR TITLE
Add ability to use custom comment model in API views

### DIFF
--- a/django_comments_xtd/api/views.py
+++ b/django_comments_xtd/api/views.py
@@ -12,12 +12,16 @@ from rest_framework.response import Response
 from rest_framework.schemas.openapi import AutoSchema
 
 from django_comments_xtd import views
+from django_comments_xtd import get_model
 from django_comments_xtd.conf import settings
 from django_comments_xtd.api import serializers
 from django_comments_xtd.models import (
-    TmpXtdComment, XtdComment, LIKEDIT_FLAG, DISLIKEDIT_FLAG
+    TmpXtdComment, LIKEDIT_FLAG, DISLIKEDIT_FLAG
 )
 from django_comments_xtd.utils import get_current_site_id
+
+
+XtdComment = get_model()
 
 
 class CommentCreate(generics.CreateAPIView):

--- a/django_comments_xtd/tests/test_api_views.py
+++ b/django_comments_xtd/tests/test_api_views.py
@@ -13,8 +13,8 @@ from django.contrib.sites.models import Site
 from django.test import TestCase
 
 from django_comments_xtd import django_comments
+from django_comments_xtd import get_model
 from django_comments_xtd.conf import settings
-from django_comments_xtd.models import XtdComment
 from django_comments_xtd.tests.models import Article
 from django_comments_xtd.tests.utils import post_comment
 
@@ -24,6 +24,8 @@ app_model_options_mock = {
         'who_can_post': 'users'
     }
 }
+
+XtdComment = get_model()
 
 
 class CommentCreateTestCase(TestCase):


### PR DESCRIPTION
In case of custom comment model, right now api views are useless because they don't know about additional fields in this model.