### PR TITLE
fix defaults for DRF views

### DIFF
--- a/django_comments_xtd/api/urls.py
+++ b/django_comments_xtd/api/urls.py
@@ -1,0 +1,23 @@
+from django.urls import path, re_path
+
+from .views import (
+    CommentCount, CommentCreate, CommentList,
+    CreateReportFlag, ToggleFeedbackFlag,
+    preview_user_avatar,
+)
+
+urlpatterns = [
+    path('comment/', CommentCreate.as_view(),
+         name='comments-xtd-api-create'),
+    path('preview/', preview_user_avatar,
+         name='comments-xtd-api-preview'),
+    re_path(r'^(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/$',
+            CommentList.as_view(), name='comments-xtd-api-list'),
+    re_path(
+        r'^(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/count/$',
+        CommentCount.as_view(), name='comments-xtd-api-count'),
+    path('feedback/', ToggleFeedbackFlag.as_view(),
+         name='comments-xtd-api-feedback'),
+    path('flag/', CreateReportFlag.as_view(),
+         name='comments-xtd-api-flag'),
+]

--- a/django_comments_xtd/api/views.py
+++ b/django_comments_xtd/api/views.py
@@ -25,9 +25,17 @@ XtdComment = get_model()
 
 
 class DefaultsMixin():
-    renderer_classes = (renderers.JSONRenderer, renderers.BrowsableAPIRenderer)
-    page_size = None
-    pagination_class = None
+    @property
+    def renderer_classes(self):
+        if self.kwargs.get('override_drf_defaults', False):
+            return (renderers.JSONRenderer, renderers.BrowsableAPIRenderer)
+        return super().renderer_classes
+
+    @property
+    def pagination_class(self):
+        if self.kwargs.get('override_drf_defaults', False):
+            return None
+        return super().pagination_class
 
 
 class CommentCreate(DefaultsMixin, generics.CreateAPIView):

--- a/django_comments_xtd/api/views.py
+++ b/django_comments_xtd/api/views.py
@@ -114,7 +114,8 @@ class CommentCount(DefaultsMixin, generics.GenericAPIView):
         return Response({'count': self.get_queryset().count()})
 
 
-class ToggleFeedbackFlag(DefaultsMixin, generics.CreateAPIView, mixins.DestroyModelMixin):
+class ToggleFeedbackFlag(
+        DefaultsMixin, generics.CreateAPIView, mixins.DestroyModelMixin):
     """Create and delete like/dislike flags."""
 
     serializer_class = serializers.FlagSerializer

--- a/django_comments_xtd/urls.py
+++ b/django_comments_xtd/urls.py
@@ -1,8 +1,8 @@
-from django.urls import include, re_path
+from django.urls import include, path, re_path
 
 from rest_framework.urlpatterns import format_suffix_patterns
 
-from django_comments_xtd import api, views
+from django_comments_xtd import views
 
 urlpatterns = [
     re_path(r'^sent/$', views.sent, name='comments-xtd-sent'),
@@ -21,21 +21,9 @@ urlpatterns = [
             name='comments-xtd-dislike-done'),
 
     # API handlers.
-    re_path(r'^api/comment/$', api.CommentCreate.as_view(),
-            name='comments-xtd-api-create'),
-    re_path(r'^api/preview/$', api.preview_user_avatar,
-            name='comments-xtd-api-preview'),
-    re_path(r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/$',
-            api.CommentList.as_view(), name='comments-xtd-api-list'),
-    re_path(
-        r'^api/(?P<content_type>\w+[-]{1}\w+)/(?P<object_pk>[-\w]+)/count/$',
-        api.CommentCount.as_view(), name='comments-xtd-api-count'),
-    re_path(r'^api/feedback/$', api.ToggleFeedbackFlag.as_view(),
-            name='comments-xtd-api-feedback'),
-    re_path(r'^api/flag/$', api.CreateReportFlag.as_view(),
-            name='comments-xtd-api-flag'),
+    path('api/', include("django_comments_xtd.api.urls"), {'override_drf_defaults': True}),
 
-    re_path(r'', include("django_comments.urls")),
+    path('', include("django_comments.urls")),
 ]
 
 

--- a/django_comments_xtd/urls.py
+++ b/django_comments_xtd/urls.py
@@ -21,7 +21,8 @@ urlpatterns = [
             name='comments-xtd-dislike-done'),
 
     # API handlers.
-    path('api/', include("django_comments_xtd.api.urls"), {'override_drf_defaults': True}),
+    path('api/', include("django_comments_xtd.api.urls"),
+         {'override_drf_defaults': True}),
 
     path('', include("django_comments.urls")),
 ]


### PR DESCRIPTION
Fixes problems described in #334 

Although I can fix this in my project, I think that using project wise DRF defaults is not something, that should `django-comments-xtd` do, especially if they can break the JavaScript code.