### PR TITLE
Issue 333

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        django: ["2.2", "3.0", "3.1"]
+        django: ["3.0", "3.1", "3.2"]
     steps:
       - uses: actions/checkout@v2
       - name: Python setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [2.9.4] -
+
+   * Fixes [issue-333](https://github.com/danirus/django-comments-xtd/issues/333) produced when using django-comments-xtd with Django 3.2 with MySQL/MariaDB. The issue raises when calling 'update()' on queries with 'sorted_by', as it is the case of the default 'objects' manager of XtdComment.
+   * Improve command 'populate_xtdcomments' to output using the stdout attribute of the BaseCommand.
+
 ## [2.9.3] - 2021-09-22
 
     * Fixes issue in 'models.publish_or_unpublish_nested_comments', when calling the update method on an empty QuerySet. See [issue-318](https://github.com/danirus/django-comments-xtd/issues/318). Thanks to @abiatarfestus, @ironworld and @Khoding.

--- a/django_comments_xtd/management/commands/populate_xtdcomments.py
+++ b/django_comments_xtd/management/commands/populate_xtdcomments.py
@@ -1,5 +1,3 @@
-import sys
-
 from django.db import connections
 from django.db.utils import ConnectionDoesNotExist, IntegrityError
 from django.core.management.base import BaseCommand
@@ -35,14 +33,17 @@ class Command(BaseCommand):
                 self.populate_db(connections[db_conn].cursor())
                 total += XtdComment.objects.using(db_conn).count()
             except ConnectionDoesNotExist:
-                print("DB connection '%s' does not exist." % db_conn)
+                self.stdout.write("DB connection '%s' does not exist."
+                                  % db_conn)
                 continue
             except IntegrityError:
                 if db_conn != 'default':
-                    print("Table '%s' (in '%s' DB connection) must be empty."
-                          % (XtdComment._meta.db_table, db_conn))
+                    self.stdout.write("Table '%s' (in '%s' DB connection) "
+                                      "must be empty."
+                                      % (XtdComment._meta.db_table, db_conn))
                 else:
-                    print("Table '%s' must be empty."
-                          % XtdComment._meta.db_table)
-                sys.exit(1)
-        print("Added %d XtdComment object(s)." % total)
+                    self.stdout.write("Table '%s' must be empty."
+                                      % XtdComment._meta.db_table)
+            finally:
+                continue
+        self.stdout.write("Added %d XtdComment object(s)." % total)

--- a/django_comments_xtd/models.py
+++ b/django_comments_xtd/models.py
@@ -68,6 +68,7 @@ class XtdComment(Comment):
                                    help_text=_("Notify follow-up comments"))
     nested_count = models.IntegerField(default=0, db_index=True)
     objects = XtdCommentManager()
+    norel_objects = CommentManager()
 
     def save(self, *args, **kwargs):
         is_new = self.pk is None
@@ -94,7 +95,8 @@ class XtdComment(Comment):
 
         self.thread_id = parent.thread_id
         self.level = parent.level + 1
-        qc_eq_thread = XtdComment.objects.filter(thread_id=parent.thread_id)
+        qc_eq_thread = XtdComment.norel_objects\
+                                 .filter(thread_id=parent.thread_id)
         qc_ge_level = qc_eq_thread.filter(level__lte=parent.level,
                                           order__gt=parent.order)
         if qc_ge_level.count():
@@ -219,13 +221,13 @@ class XtdComment(Comment):
 
 
 def publish_or_unpublish_nested_comments(comment, are_public=False):
-    qs = get_model().objects.filter(~Q(pk=comment.id), parent_id=comment.id)
+    qs = get_model().norel_objects.filter(~Q(pk=comment.id),
+                                          parent_id=comment.id)
     nested = [cm.id for cm in qs]
-    if qs:
-        qs.update(is_public=are_public)
+    qs.update(is_public=are_public)
     while len(nested):
         cm_id = nested.pop()
-        qs = XtdComment.objects.filter(~Q(pk=cm_id), parent_id=cm_id)
+        qs = XtdComment.norel_objects.filter(~Q(pk=cm_id), parent_id=cm_id)
         nested.extend([cm.id for cm in qs])
         qs.update(is_public=are_public)
     # Update nested_count in parents comments in the same thread.
@@ -236,10 +238,10 @@ def publish_or_unpublish_nested_comments(comment, are_public=False):
         op = F('nested_count') + comment.nested_count
     else:
         op = F('nested_count') - comment.nested_count
-    XtdComment.objects.filter(thread_id=comment.thread_id,
-                              level__lt=comment.level,
-                              order__lt=comment.order)\
-                      .update(nested_count=op)
+    XtdComment.norel_objects.filter(thread_id=comment.thread_id,
+                                    level__lt=comment.level,
+                                    order__lt=comment.order)\
+                            .update(nested_count=op)
 
 
 def publish_or_unpublish_on_pre_save(sender, instance, raw, using, **kwargs):

--- a/django_comments_xtd/tests/test_cmd_initialize_nested_count.py
+++ b/django_comments_xtd/tests/test_cmd_initialize_nested_count.py
@@ -45,7 +45,7 @@ class InitializeNesteCoundCmdTest(TestCase):
 
     def test_calling_command_computes_nested_count(self):
         # Set all comments nested_count field to 0.
-        XtdComment.objects.update(nested_count=0)
+        XtdComment.norel_objects.update(nested_count=0)
         out = StringIO()
         call_command('initialize_nested_count', stdout=out)
         self.assertIn("Updated 9 XtdComment object(s).", out.getvalue())

--- a/django_comments_xtd/views.py
+++ b/django_comments_xtd/views.py
@@ -353,7 +353,7 @@ def mute(request, key):
                                       comment=tmp_comment,
                                       request=request)
 
-    XtdComment.objects.filter(
+    XtdComment.norel_objects.filter(
         content_type=tmp_comment.content_type,
         object_pk=tmp_comment.object_pk,
         user_email=tmp_comment.user_email,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,38 +96,43 @@ specific features, or check out the use cases to see how others customize it.
 Change Log
 ==========
 
+## [2.9.4] -
+
+   * Fixes `issue #333 <https://github.com/danirus/django-comments-xtd/issues/333>`_ produced when using django-comments-xtd with Django 3.2 with MySQL/MariaDB. The issue raises when calling 'update()' on queries with 'sorted_by', as it is the case of the default 'objects' manager of XtdComment.
+   * Improve command 'populate_xtdcomments' to output using the stdout attribute of the BaseCommand.
+
 [2.9.3] - 2021-09-22
 --------------------
 
-    * Fixes issue in 'models.publish_or_unpublish_nested_comments', when calling the update method on an empty QuerySet. See [issue-318](https://github.com/danirus/django-comments-xtd/issues/318). Thanks to @abiatarfestus, @ironworld and @Khoding.
-    * Enhance the queryset in notify_comment_followers using distinct when possible. And fallback to the previous queryset when distinct is not supported, as is the case for sqlite. See [issue-326](https://github.com/danirus/django-comments-xtd/issues/326). Thanks to @enzedonline.
+    * Fixes issue in 'models.publish_or_unpublish_nested_comments', when calling the update method on an empty QuerySet. See `issue #318 <https://github.com/danirus/django-comments-xtd/issues/318>`_. Thanks to @abiatarfestus, @ironworld and @Khoding.
+    * Enhance the queryset in notify_comment_followers using distinct when possible. And fallback to the previous queryset when distinct is not supported, as is the case for sqlite. See `issue #326 <https://github.com/danirus/django-comments-xtd/issues/326>`_. Thanks to @enzedonline.
 
 [2.9.2] - 2021-06-19
 --------------------
 
-    * Fixes issue with nested_count XtdComment's attribute being wrongly computed when comment threads are more than 2 level deep and have more than 1 thread. See [PR-312](https://github.com/danirus/django-comments-xtd/pull/312).
-    * Resolves limitation in API views. Avoid using explicit XtdComment model and rather use the `get_model` function to allow using customized comment models with API. See [PR-313](https://github.com/danirus/django-comments-xtd/pull/313). Thanks to @r4fek.
-    * Enhance comment form initialization, so that original fields are not override but rather only some of its attributes. See [PR-315](https://github.com/danirus/django-comments-xtd/pull/315). Thanks to @dest81.
+    * Fixes issue with nested_count XtdComment's attribute being wrongly computed when comment threads are more than 2 level deep and have more than 1 thread. See `PR-312 <https://github.com/danirus/django-comments-xtd/pull/312>`_.
+    * Resolves limitation in API views. Avoid using explicit XtdComment model and rather use the `get_model` function to allow using customized comment models with API. See `PR-313 <https://github.com/danirus/django-comments-xtd/pull/313>`_. Thanks to @r4fek.
+    * Enhance comment form initialization, so that original fields are not override but rather only some of its attributes. See `PR-315 <https://github.com/danirus/django-comments-xtd/pull/315>`_. Thanks to @dest81.
 
 [2.9.1] - 2021-04-25
 --------------------
 
-    * Fixes issue when the 'sent' view does not receive a 'c' query string parameter. See [PR-305](https://github.com/danirus/django-comments-xtd/pull/305). Thanks to @dest81.
+    * Fixes issue when the 'sent' view does not receive a 'c' query string parameter. See `PR-305 <https://github.com/danirus/django-comments-xtd/pull/305>`_. Thanks to @dest81.
 
 [2.9.0] - 2021-03-20
 --------------------
 
     * Drops support for Django 2.0 and 2.1.
     * Requires django-contrib-comments >= 2.1, and djangorestframework >= 3.12.
-    * Fixes warning when generating the OpenAPI schema. Thanks to @ivanychev. See [PR-296](https://github.com/danirus/django-comments-xtd/pull/296).
-    * Fixes issue with `render_xtdcomment_tree` templatetag, thanks to @dest81. See [PR-295](https://github.com/danirus/django-comments-xtd/pull/295).
+    * Fixes warning when generating the OpenAPI schema. Thanks to @ivanychev. See `PR-296 <https://github.com/danirus/django-comments-xtd/pull/296>`_.
+    * Fixes issue with `render_xtdcomment_tree` templatetag, thanks to @dest81. See `PR-295 <https://github.com/danirus/django-comments-xtd/pull/295>`_.
     * Fixes issue `#291 <https://github.com/danirus/django-comments-xtd/issues/291>`_, about the frontend plugin not being aware of the setting COMMENTS_XTD_DEFAULT_FOLLOWUP. It also fixes the content of the `login_url` props attribute. Its value is now the content of `settings.LOGIN_URL`.
     * Fixes issue `#284 <https://github.com/danirus/django-comments-xtd/issues/284>`_, about sending a comment twice by clicking the comment send button twice. It happened when not using the JavaScript plugin.
 
 [2.8.5] - 2021-03-02
 --------------------
 
-    * Fixes issue #292 with the workflow upload-pypi.yml, that caused the package bundle to be built without JavaScript files.
+    * Fixes issue `#292 <https://github.com/danirus/django-comments-xtd/issues/292>`_ with the workflow upload-pypi.yml, that caused the package bundle to be built without JavaScript files.
 
 [2.8.4] - 2021-02-28
 --------------------

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ django_find_project = false
 
 [tox]
 skipsdist = True
-envlist = py-3.8-django-{2.2,3.0,3.1}
+envlist = py-3.8-django-{3.0,3.1,3.2}
 
 [travis]
 python =
@@ -16,9 +16,9 @@ python =
 
 [travis:env]
 DJANGO =
-  2.2: django-2.2
   3.0: django-3.0
   3.1: django-3.1
+  3.2: django-3.2
 [testenv]
 changedir = {toxinidir}/django_comments_xtd
 commands = py.test -rw --cov-config .coveragerc --cov django_comments_xtd
@@ -31,11 +31,11 @@ deps =
     pytest-cov
     pytest-django
     selenium
-    py-3.8-django-2.2: django>=2.2,<2.3
     py-3.8-django-3.0: django>=3.0,<3.1
     py-3.8-django-3.1: django>=3.1,<3.2
-    py-3.8-django-{2.2,3.0,3.1}: djangorestframework>=3.12
-    py-3.8-django-{2.2,3.0,3.1}: django-contrib-comments>=2.1
+    py-3.8-django-3.2: django>=3.2,<3.3
+    py-3.8-django-{3.0,3.1,3.2}: djangorestframework>=3.12,<3.13
+    py-3.8-django-{3.0,3.1,3.2}: django-contrib-comments>=2.1,<2.2
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
     DJANGO_SETTINGS_MODULE=django_comments_xtd.tests.settings


### PR DESCRIPTION
 * Fixes [issue-333](https://github.com/danirus/django-comments-xtd/issues/333) produced when using django-comments-xtd with Django 3.2 with MySQL/MariaDB. The issue raises when calling 'update()' on queries with 'sorted_by', as it is the case of the default 'objects' manager of XtdComment.
 * Improve command 'populate_xtdcomments' to output using the stdout attribute of the BaseCommand.
