### PR TITLE
fix preview clashing with new include parameter

### DIFF
--- a/django_comments_xtd/api/views.py
+++ b/django_comments_xtd/api/views.py
@@ -152,7 +152,7 @@ class CreateReportFlag(DefaultsMixin, generics.CreateAPIView):
 
 
 @api_view(["POST"])
-def preview_user_avatar(request):
+def preview_user_avatar(request, *args, **kwargs):
     """Fetch the image associated with the user previewing the comment."""
     print("I am here")
     temp_comment = TmpXtdComment({


### PR DESCRIPTION
I realized, that the preview view doesn't work after I added the `override_drf_defaults` parameter to `urls.py`. This fixes it.