### PR TITLE
Remove mock dependency

### DIFF
--- a/django_comments_xtd/api/views.py
+++ b/django_comments_xtd/api/views.py
@@ -154,7 +154,6 @@ class CreateReportFlag(DefaultsMixin, generics.CreateAPIView):
 @api_view(["POST"])
 def preview_user_avatar(request, *args, **kwargs):
     """Fetch the image associated with the user previewing the comment."""
-    print("I am here")
     temp_comment = TmpXtdComment({
         'user': None,
         'user_email': request.data['email']

--- a/django_comments_xtd/tests/test_api_views.py
+++ b/django_comments_xtd/tests/test_api_views.py
@@ -2,10 +2,7 @@ from __future__ import unicode_literals
 
 from datetime import datetime
 import json
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType

--- a/django_comments_xtd/tests/test_forms.py
+++ b/django_comments_xtd/tests/test_forms.py
@@ -5,10 +5,7 @@ from django_comments_xtd.models import TmpXtdComment
 from django_comments_xtd.forms import XtdCommentForm
 from django_comments_xtd.tests.models import Article
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 class GetFormTestCase(TestCase):

--- a/django_comments_xtd/tests/test_get_version.py
+++ b/django_comments_xtd/tests/test_get_version.py
@@ -1,7 +1,4 @@
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 from django.test import TestCase
 

--- a/django_comments_xtd/tests/test_models.py
+++ b/django_comments_xtd/tests/test_models.py
@@ -1,7 +1,4 @@
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 from datetime import datetime
 
 from django.db.models.signals import pre_save

--- a/django_comments_xtd/tests/test_moderation.py
+++ b/django_comments_xtd/tests/test_moderation.py
@@ -2,10 +2,7 @@ from __future__ import unicode_literals
 
 import re
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 from datetime import datetime, timedelta
 
 import django
@@ -13,10 +10,7 @@ from django.contrib.auth.models import AnonymousUser, User
 from django.test import TestCase, RequestFactory
 from django.urls import reverse
 
-try:
-    from django_comments.models import CommentFlag
-except ImportError:
-    from django.contrib.comments.models import CommentFlag
+from django_comments.models import CommentFlag
 
 from django_comments_xtd import django_comments, views
 from django_comments_xtd.models import LIKEDIT_FLAG, DISLIKEDIT_FLAG

--- a/django_comments_xtd/tests/test_serializers.py
+++ b/django_comments_xtd/tests/test_serializers.py
@@ -2,10 +2,7 @@ from __future__ import unicode_literals
 
 from datetime import datetime
 import pytz
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType

--- a/django_comments_xtd/tests/test_templatetags.py
+++ b/django_comments_xtd/tests/test_templatetags.py
@@ -1,11 +1,5 @@
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-import unittest
-
 from django.contrib.auth.models import AnonymousUser
-from django.template import Context, Template, TemplateSyntaxError
+from django.template import Context, Template
 from django.test import TestCase as DjangoTestCase
 
 from django_comments_xtd.models import XtdComment

--- a/django_comments_xtd/tests/test_views.py
+++ b/django_comments_xtd/tests/test_views.py
@@ -3,17 +3,13 @@ from __future__ import unicode_literals
 import re
 import random
 import string
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 from datetime import datetime
 
 # from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.contrib.auth.models import AnonymousUser, User
-from django.http.response import Http404
 from django.test import TestCase, RequestFactory
 from django.urls import reverse
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,21 @@
 [tool.poetry]
 name = "django-comments-xtd"
-version = "2.3.1"
+version = "2.9.3"
 description = "Django Comments Framework extension app with thread support, follow up notifications and email confirmations."
-authors = ["Daniela Rus Morales <mbox@danir.us>"]
+authors = ["Daniela Rus Morales <danirus@eml.cc>"]
 
 [tool.poetry.dependencies]
-python = "^3.4.0"
-django-contrib-comments = "^1.8.0"
-djangorestframework = "^3.12.0"
-six = "^1.12.0"
-Django = "^2.0.0"
-docutils = "^0.14.0"
-django-markdown2 = "^0.3.1"
+python = "^3"
+Django = "^3"
+django-contrib-comments = "^2.1"
+djangorestframework = "^3.12"
+six = "^1.16"
+docutils = "^0.17"
+django-markdown2 = "^0.3"
 
 [tool.poetry.dev-dependencies]
-coverage = "^4.5.0"
-mock = "^2.0.0"
+coverage = "^5.5"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.1,<1.2"]
 build-backend = "poetry.masonry.api"

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,6 @@
-django-contrib-comments
-djangorestframework
+Django>=3,<4
+django-contrib-comments>=2.1,<2.2
+djangorestframework>=3.12,<3.13
+django-markdown2>=0.3,<0.4
+docutils>=0.17,<0.18
 six
-Django
-docutils
-django-markdown2

--- a/requirements_tests.pip
+++ b/requirements_tests.pip
@@ -1,3 +1,2 @@
 -r requirements.pip
 coverage
-mock

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,9 @@ setup(
     maintainer_email="danirus@eml.cc",
     url="http://pypi.python.org/pypi/django-comments-xtd",
     install_requires=[
-        'Django>=2.2',
-        'django-contrib-comments>=2.1',
-        'djangorestframework>=3.12',
+        'Django>=3,<4',
+        'django-contrib-comments>=2.1,<2.2',
+        'djangorestframework>=3.12,<3.13',
         'docutils',
         'six',
     ],


### PR DESCRIPTION
This PR:
 * Updates version of required dependencies.
 * Removes dependency on the **mock** package, as it's already part of the **unittest** Python 3 standard lib package.
 * Updates content of `pyproject.toml` file.