### PR TITLE
ugettext_lazy > gettext_lazy (for Django 4.0)

### DIFF
--- a/django_comments_xtd/models.py
+++ b/django_comments_xtd/models.py
@@ -4,7 +4,7 @@ from django.db.transaction import atomic
 from django.contrib.contenttypes.models import ContentType
 from django.core import signing
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_comments.managers import CommentManager
 from django_comments.models import Comment, CommentFlag

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -57,7 +57,7 @@ The new class ``MyComment`` extends django_comments_xtd's ``XtdComment`` with a 
 The forms module extends ``XtdCommentForm`` and rewrites the method ``get_comment_create_data``::
 
   from django import forms
-  from django.utils.translation import ugettext_lazy as _
+  from django.utils.translation import gettext_lazy as _
 
   from django_comments_xtd.forms import XtdCommentForm
   from django_comments_xtd.models import TmpXtdComment
@@ -81,7 +81,7 @@ The forms module extends ``XtdCommentForm`` and rewrites the method ``get_commen
 The admin module provides a new class MyCommentAdmin that inherits from XtdCommentsAdmin and customize some of its attributes to include the new field ``title``::
 
   from django.contrib import admin
-  from django.utils.translation import ugettext_lazy as _
+  from django.utils.translation import gettext_lazy as _
 
   from django_comments_xtd.admin import XtdCommentsAdmin
   from custom_comments.mycomments.models import MyComment

--- a/example/comp/templatetags/comp_filters.py
+++ b/example/comp/templatetags/comp_filters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.template import Library, TemplateSyntaxError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django.conf import settings
 

--- a/example/custom/mycomments/admin.py
+++ b/example/custom/mycomments/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_comments_xtd.admin import XtdCommentsAdmin
 from custom.mycomments.models import MyComment

--- a/example/custom/mycomments/forms.py
+++ b/example/custom/mycomments/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_comments_xtd.forms import XtdCommentForm
 from django_comments_xtd.models import TmpXtdComment


### PR DESCRIPTION
Changed all the ugettext_lazy with gettext_lazy for compatibility with [Django 4.0](https://docs.djangoproject.com/en/4.0/releases/4.0/)

as far as I know this is the only problem preventing to use it fully with the latest update of Django