### PR TITLE
French Grammar is so complicated

### DIFF
--- a/django_comments_xtd/locale/fr/LC_MESSAGES/django.po
+++ b/django_comments_xtd/locale/fr/LC_MESSAGES/django.po
@@ -65,7 +65,7 @@ msgstr "Avertir des commentaires suivants"
 
 #: views.py:48
 msgid "comment confirmation request"
-msgstr "Confirmation du commentaire envoyée"
+msgstr "Confirmation du commentaire envoyé"
 
 #: views.py:209
 msgid "new comment posted"


### PR DESCRIPTION
just a grammar correction, "envoyé" must be "accordé" (may be in-tune in english) with "commentaire"
and "commentaire" is a male gender noum so only one e at the end of the word.