### PR TITLE
add ordering filter and submit_date_timestamp to the API

### DIFF
--- a/django_comments_xtd/api/serializers.py
+++ b/django_comments_xtd/api/serializers.py
@@ -245,6 +245,8 @@ class ReadCommentSerializer(serializers.ModelSerializer):
     user_moderator = serializers.SerializerMethodField()
     user_avatar = serializers.SerializerMethodField()
     submit_date = serializers.SerializerMethodField()
+    submit_date_timestamp = serializers.CharField(
+        source="submit_date", read_only=True)
     parent_id = serializers.IntegerField(default=0, read_only=True)
     level = serializers.IntegerField(read_only=True)
     is_removed = serializers.BooleanField(read_only=True)
@@ -257,7 +259,8 @@ class ReadCommentSerializer(serializers.ModelSerializer):
         model = XtdComment
         fields = ('id', 'user_name', 'user_url', 'user_moderator',
                   'user_avatar', 'permalink', 'comment', 'submit_date',
-                  'parent_id', 'level', 'is_removed', 'allow_reply', 'flags')
+                  'submit_date_timestamp', 'parent_id', 'level', 'is_removed',
+                  'allow_reply', 'flags')
 
     def __init__(self, *args, **kwargs):
         self.request = kwargs['context']['request']

--- a/django_comments_xtd/api/views.py
+++ b/django_comments_xtd/api/views.py
@@ -6,7 +6,9 @@ from django.utils.module_loading import import_string
 
 from django_comments.models import CommentFlag
 from django_comments.views.moderation import perform_flag
-from rest_framework import generics, mixins, permissions, status, renderers
+from rest_framework import (
+    generics, mixins, permissions, status, renderers, filters
+)
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.schemas.openapi import AutoSchema
@@ -36,6 +38,7 @@ class DefaultsMixin():
         if self.kwargs.get('override_drf_defaults', False):
             return None
         return super().pagination_class
+    filter_backends = [filters.OrderingFilter]
 
 
 class CommentCreate(DefaultsMixin, generics.CreateAPIView):


### PR DESCRIPTION
I added OrderingFilter to the comments API to enable sorting by particular fields.
I also added `submit_date_timestamp` to be able to sort by date and it could be also helpful to determine the exact time in some applications (as `submit_date` is dependend on server timezone).