### PR TITLE
add interchangeable model keys support

### DIFF
--- a/django_comments_xtd/api/frontend.py
+++ b/django_comments_xtd/api/frontend.py
@@ -2,6 +2,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils.module_loading import import_string
 
 from django_comments.forms import CommentSecurityForm
+from django_comments.utils import get_key_value
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
@@ -25,7 +26,7 @@ class CommentBoxDriver(object):
     def get_queryset(cls, ctype, obj, request):
         return XtdComment.objects.filter(
             content_type=ctype,
-            object_pk=obj.pk,
+            object_pk=get_key_value(obj),
             site__pk=get_current_site_id(request),
             is_public=True,
         )
@@ -109,10 +110,10 @@ class CommentBoxDriver(object):
             "flag_url": cls._reverse("comments-flag", args=(0,)),
             "list_url": cls._reverse('comments-xtd-api-list',
                                      kwargs={'content_type': ctype_slug,
-                                             'object_pk': obj.id}),
+                                             'object_pk': get_key_value(obj)}),
             "count_url": cls._reverse('comments-xtd-api-count',
                                       kwargs={'content_type': ctype_slug,
-                                              'object_pk': obj.id}),
+                                              'object_pk': get_key_value(obj)}),
             "send_url": cls._reverse("comments-xtd-api-create"),
             "preview_url": cls._reverse("comments-xtd-api-preview"),
             "form": {

--- a/django_comments_xtd/api/serializers.py
+++ b/django_comments_xtd/api/serializers.py
@@ -10,6 +10,7 @@ from django_comments import get_form
 from django_comments.forms import CommentSecurityForm
 from django_comments.models import CommentFlag
 from django_comments.signals import comment_will_be_posted, comment_was_posted
+from django_comments.utils import get_key
 from rest_framework import exceptions, serializers
 
 from django_comments_xtd import get_model, signed, views
@@ -89,7 +90,7 @@ class WriteCommentSerializer(serializers.Serializer):
                                                "object_pk field.")
         try:
             model = apps.get_model(*ctype.split(".", 1))
-            target = model._default_manager.get(pk=object_pk)
+            target = model._default_manager.get(**{get_key(model): object_pk})
             whocan = get_app_model_options(content_type=ctype)['who_can_post']
         except (AttributeError, TypeError, LookupError):
             raise serializers.ValidationError("Invalid content_type value: %r"

--- a/django_comments_xtd/forms.py
+++ b/django_comments_xtd/forms.py
@@ -3,6 +3,7 @@ from django.apps import apps
 from django.utils.translation import gettext_lazy as _
 
 from django_comments.forms import CommentForm
+from django_comments.utils import get_key
 
 from django_comments_xtd.conf import settings
 from django_comments_xtd.models import TmpXtdComment
@@ -60,7 +61,7 @@ class XtdCommentForm(CommentForm):
         ctype = data.get('content_type')
         object_pk = data.get('object_pk')
         model = apps.get_model(ctype.app_label, ctype.model)
-        target = model._default_manager.get(pk=object_pk)
+        target = model._default_manager.get(**{get_key(model): object_pk})
         data.update({'thread_id': 0, 'level': 0, 'order': 1,
                      'parent_id': self.cleaned_data['reply_to'],
                      'followup': self.cleaned_data['followup'],


### PR DESCRIPTION
This relies on https://github.com/django/django-contrib-comments/pull/188 and adds interchangeable model keys also to `django-comments-xtd`.