### PR TITLE
fix: enable content_object in followup email notification context

### DIFF
--- a/django_comments_xtd/moderation.py
+++ b/django_comments_xtd/moderation.py
@@ -102,7 +102,7 @@ class SpamModerator(XtdCommentModerator):
         except IndexError:
             return False
         else:
-            if(BlackListedDomain.objects.filter(domain=domain).count()):
+            if BlackListedDomain.objects.filter(domain=domain).count():
                 return False
             return super(SpamModerator, self).allow(comment, content_object,
                                                     request)

--- a/django_comments_xtd/views.py
+++ b/django_comments_xtd/views.py
@@ -286,7 +286,7 @@ def notify_comment_followers(comment):
         mute_url = reverse('comments-xtd-mute', args=[key.decode('utf-8')])
         message_context = {'user_name': name,
                            'comment': comment,
-                           # 'content_object': target,
+                           'content_object': comment.content_object,
                            'mute_url': mute_url,
                            'site': comment.site}
         text_message = text_message_template.render(message_context)

--- a/django_comments_xtd/views.py
+++ b/django_comments_xtd/views.py
@@ -26,7 +26,7 @@ from django_comments.views.utils import next_redirect, confirmation_view
 from django_comments_xtd import (
     comment_was_posted, comment_will_be_posted,
     get_form, get_model as get_comment_model,
-    signals, signed  #  module.
+    signals, signed
 )
 from django_comments_xtd.conf import settings
 from django_comments_xtd.models import (


### PR DESCRIPTION
fixes #377 