### PR TITLE
fix: add missing translation calls

### DIFF
--- a/django_comments_xtd/locale/de/LC_MESSAGES/django.po
+++ b/django_comments_xtd/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-25 20:14+0100\n"
+"POT-Creation-Date: 2022-09-17 23:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Diedrich Vorberg <diedrich@tux4web.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -18,9 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: api/serializers.py:192 templates/comments/list.html:17
-#: templates/django_comments_xtd/comment.html:14
-#: templates/django_comments_xtd/comment_tree.html:34
+#: api/serializers.py:277 templates/comments/list.html:17
+#: templates/django_comments_xtd/comment.html:15
+#: templates/django_comments_xtd/comment_tree.html:36
 msgid "This comment has been removed."
 msgstr "Dieser Kommentar wurde entfernt."
 
@@ -28,41 +28,66 @@ msgstr "Dieser Kommentar wurde entfernt."
 msgid "Notify me about follow-up comments"
 msgstr "Benachrichtigung bei neuen Nachrichten"
 
-#: forms.py:28
+#: forms.py:29
 msgid "Name"
 msgstr "Name"
 
-#: forms.py:29
+#: forms.py:31
 msgid "name"
 msgstr "Name"
 
-#: forms.py:32
+#: forms.py:33
 msgid "Mail"
 msgstr "e-Mail"
 
-#: forms.py:32
+#: forms.py:34
 msgid "Required for comment verification"
 msgstr "Wird für die Bestätigung benötigt"
 
-#: forms.py:33
+#: forms.py:36
 msgid "mail address"
 msgstr "e-Mail Adresse"
 
-#: forms.py:36
+#: forms.py:38
 msgid "Link"
 msgstr "Link"
 
-#: forms.py:38
+#: forms.py:41
 msgid "url your name links to (optional)"
 msgstr "Web-Adresse, auf die dein Name verlinken soll"
 
-#: forms.py:41
+#: forms.py:45
 msgid "Your comment"
 msgstr "Kommentar"
 
-#: models.py:70
+#: models.py:68
 msgid "Notify follow-up comments"
 msgstr "Benachrichtigung bei neuen Nachrichten"
+
+#: templates/404.html:9
+msgid "Page not found"
+msgstr "Seite nicht gefunden"
+
+#: templates/comments/comment_notification_email.txt:1
+msgid "A new comment has been sent to the following URL:"
+msgstr "Es wurde ein neuer Kommentar zu folgender URL gesendet:"
+
+#: templates/comments/comment_notification_email.txt:5
+#: templates/django_comments_xtd/email_followup_comment.html:5
+#: templates/django_comments_xtd/email_followup_comment.txt:8
+msgid "Sent by"
+msgstr "Eingereicht von"
+
+#: templates/comments/comment_notification_email.txt:6
+msgid "Email address"
+msgstr "e-Mail Adresse"
+
+#: templates/comments/comment_notification_email.txt:8
+#: templates/django_comments_xtd/email_confirmation_request.txt:7
+#: templates/django_comments_xtd/email_followup_comment.txt:10
+#: templates/django_comments_xtd/removal_notification_email.txt:3
+msgid "Comment"
+msgstr "Kommentar"
 
 #: templates/comments/delete.html:5
 msgid "Remove comment"
@@ -78,10 +103,20 @@ msgid ""
 "it from the site, only prevents your website from showing the text. Click on "
 "the remove button to delete the following comment:"
 msgstr ""
+"Als Moderator kannst du Kommentare löschen. Durch das Löschen eines "
+"Kommentars wird dieser nicht von der Website entfernt, sondern nur "
+"verhindert, dass der Text auf der Website angezeigt wird. Klicke auf "
+"den Button \"Entfernen\", um den folgenden Kommentar zu löschen:"
 
-#: templates/comments/delete.html:41
+#: templates/comments/delete.html:45
 msgid "Remove"
 msgstr "Entfernen"
+
+#: templates/comments/delete.html:46 templates/comments/flag.html:57
+#: templates/django_comments_xtd/dislike.html:74
+#: templates/django_comments_xtd/like.html:73
+msgid "cancel"
+msgstr "Abbrechen"
 
 #: templates/comments/deleted.html:5
 msgid "Comment removed"
@@ -111,22 +146,16 @@ msgid ""
 msgstr ""
 "Klicke auf die Flagge, um diesen Kommentar als unangemessen zu markieren."
 
-#: templates/comments/flag.html:40
-#: templates/django_comments_xtd/comment.html:10
-#: templates/django_comments_xtd/dislike.html:48
-#: templates/django_comments_xtd/like.html:46
+#: templates/comments/flag.html:41
+#: templates/django_comments_xtd/comment.html:11
+#: templates/django_comments_xtd/dislike.html:49
+#: templates/django_comments_xtd/like.html:47
 msgid "Posted to "
 msgstr "Gesendet an "
 
-#: templates/comments/flag.html:55
+#: templates/comments/flag.html:56
 msgid "Flag"
 msgstr "Markierung"
-
-#: templates/comments/flag.html:56
-#: templates/django_comments_xtd/dislike.html:73
-#: templates/django_comments_xtd/like.html:72
-msgid "cancel"
-msgstr "Abbrechen"
 
 #: templates/comments/flagged.html:5
 msgid "Comment flagged"
@@ -145,7 +174,7 @@ msgid "preview"
 msgstr "Vorschau"
 
 #: templates/comments/list.html:25
-#: templates/django_comments_xtd/comment_tree.html:43
+#: templates/django_comments_xtd/comment_tree.html:45
 msgid "Reply"
 msgstr "Antwort"
 
@@ -163,6 +192,10 @@ msgstr ""
 "Eine Bestätigungs-Mail wurde an deine Adresse gesendet. Bitte klicke auf den "
 "Link in der Mail, damit dein Kommentar hier erscheint."
 
+#: templates/comments/posted.html:17
+msgid "Go back to"
+msgstr "Gehe zurück zu"
+
 #: templates/comments/preview.html:5 templates/comments/preview.html:10
 msgid "Preview your comment"
 msgstr "Vorschau für deinen Kommentar"
@@ -175,7 +208,7 @@ msgstr "Vorschau deines Kommentars für:"
 msgid "Empty comment."
 msgstr "Leerer Kommentar."
 
-#: templates/comments/preview.html:41
+#: templates/comments/preview.html:48
 #: templates/django_comments_xtd/reply.html:32
 msgid "Post your comment"
 msgstr "Schicke deinen Kommentar ab"
@@ -184,24 +217,27 @@ msgstr "Schicke deinen Kommentar ab"
 msgid "List of comments"
 msgstr "Liste der Kommentare"
 
-#: templates/django_comments_xtd/comment_tree.html:13
+#: templates/django_comments_xtd/comment_list.html:21
+msgid "No comments yet."
+msgstr "Keine Kommentare bisher."
+
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "moderator"
 msgstr "Moderator"
 
-#: templates/django_comments_xtd/comment_tree.html:13
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "comment permalink"
 msgstr "Permanenter Link"
 
-#: templates/django_comments_xtd/comment_tree.html:18
+#: templates/django_comments_xtd/comment_tree.html:17
 #, python-format
 msgid "A user has flagged this comment as inappropriate."
 msgid_plural "%(counter)s users have flagged this comment as inappropriate."
-msgstr[0] ""
-"Ein Benutzer hat diesen Kommentar als unangemessen gekennzeichnet."
+msgstr[0] "Ein Benutzer hat diesen Kommentar als unangemessen gekennzeichnet."
 msgstr[1] ""
 "%(counter)s Benutzer haben diesen Kommentar als unangemessen gekennzeichnet."
 
-#: templates/django_comments_xtd/comment_tree.html:22
+#: templates/django_comments_xtd/comment_tree.html:21
 msgid "comment flagged"
 msgstr "Kommentar markiert"
 
@@ -209,7 +245,7 @@ msgstr "Kommentar markiert"
 msgid "flag comment"
 msgstr "Kommentar markieren"
 
-#: templates/django_comments_xtd/comment_tree.html:28
+#: templates/django_comments_xtd/comment_tree.html:30
 msgid "remove comment"
 msgstr "Kommentar entfernen"
 
@@ -243,20 +279,20 @@ msgstr "Magst du diesen Kommentar wirklich nicht?"
 msgid "Please, confirm your opinion about the comment."
 msgstr "Bestätige bitte deine Meinung zu diesem Kommentar."
 
-#: templates/django_comments_xtd/dislike.html:61
+#: templates/django_comments_xtd/dislike.html:62
 msgid ""
 "Click on the \"withdraw\" button if you want to withdraw your negative "
 "opinion on this comment."
 msgstr ""
-"Klick auf den „Zurückziehen“-Button, wenn du deine Mainung zu diesem "
+"Klick auf den „Zurückziehen“-Button, wenn du deine Meinung zu diesem "
 "Kommentar zurückziehen möchtest."
 
-#: templates/django_comments_xtd/dislike.html:69
-#: templates/django_comments_xtd/like.html:68
+#: templates/django_comments_xtd/dislike.html:70
+#: templates/django_comments_xtd/like.html:69
 msgid "Withdraw"
 msgstr "Zurückziehen"
 
-#: templates/django_comments_xtd/dislike.html:71
+#: templates/django_comments_xtd/dislike.html:72
 msgid "I dislike it"
 msgstr "Er gefällt mir nicht"
 
@@ -269,13 +305,77 @@ msgstr "Der Kommentar gefällt dir nicht."
 msgid "Thanks for taking the time to participate."
 msgstr "Danke, dass du mitmachst!"
 
+#: templates/django_comments_xtd/email_confirmation_request.html:3
+#: templates/django_comments_xtd/email_confirmation_request.txt:3
+msgid ""
+"You or someone in behalf of you have requested to post a comment into this "
+"page:"
+msgstr ""
+"Du oder jemand in deinem Namen hat angefragt, einen Kommentar auf dieser "
+"Seite zu veröffentlichen:"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:7
+#: templates/django_comments_xtd/email_followup_comment.html:8
+msgid "The comment"
+msgstr "Der Kommentar"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:11
+#: templates/django_comments_xtd/email_confirmation_request.txt:11
+#, python-format
+msgid ""
+"If you do not wish to post the comment, please ignore this message or report "
+"an incident to %(contact)s. Otherwise click on the link below to confirm the "
+"comment."
+msgstr ""
+"Wenn du den Kommentar nicht veröffentlichen möchtest, ignoriere bitte diese "
+"Nachricht oder melde einen Vorfall an %(contact)s. Andernfalls klicke auf "
+"den Link unten, um den Kommentar zu bestätigen."
+
+#: templates/django_comments_xtd/email_confirmation_request.html:15
+#: templates/django_comments_xtd/email_confirmation_request.txt:15
+msgid ""
+"If clicking does not work, you can also copy and paste the address into your "
+"browser's address window."
+msgstr ""
+"Wenn das Anklicken nicht funktioniert, kannst du die Adresse auch kopieren "
+"und in das Adressfeld deines Browsers einfügen."
+
+#: templates/django_comments_xtd/email_confirmation_request.html:17
+#: templates/django_comments_xtd/email_confirmation_request.txt:16
+msgid "Thanks for your comment!"
+msgstr "Danke für deinen Kommentar!"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:19
+#: templates/django_comments_xtd/email_confirmation_request.txt:19
+#: templates/django_comments_xtd/email_followup_comment.html:14
+#: templates/django_comments_xtd/email_followup_comment.txt:20
+msgid "Kind regards"
+msgstr "Freundlicher Gruß"
+
+#: templates/django_comments_xtd/email_followup_comment.html:3
 #: templates/django_comments_xtd/email_followup_comment.txt:4
 msgid "There is a new comment following up yours."
 msgstr "Es gibt einen neuen Folge-Kommentar."
 
-#: templates/django_comments_xtd/email_followup_comment.txt:20
-msgid "Kind regards"
-msgstr "Freundlicher Gruß"
+#: templates/django_comments_xtd/email_followup_comment.html:12
+#, python-format
+msgid ""
+"Click <a href=\"http://%(site_domain)s%(mute_url)s\">http://%(site_domain)s"
+"%(mute_url_short)s...</a> to mute the comments thread. You will no longer "
+"receive follow-up notifications."
+msgstr ""
+"Klicke auf <a href=\"http://%(site_domain)s%(mute_url)s\">http://%(site_domain)s%(mute_url_short)s...</a>, um den Kommentar-Thread stummzuschalten. Du wirst dann keine weiteren Benachrichtigungen mehr erhalten."
+
+#: templates/django_comments_xtd/email_followup_comment.txt:6
+msgid "Post"
+msgstr "Beitrag"
+
+#: templates/django_comments_xtd/email_followup_comment.txt:15
+msgid ""
+"Click on the following link to mute the comments thread. You will no longer "
+"receive follow-up notifications:"
+msgstr ""
+"Klicke auf den folgenden Link, um den Kommentar-Thread stumm zu schalten. Du wirst dann keine weiteren Benachrichtigungen mehr erhalten:"
 
 #: templates/django_comments_xtd/like.html:15
 msgid "You liked this comment, do you want to change it?"
@@ -285,7 +385,7 @@ msgstr "Dir gefällt dieser Kommentar. Möchtest du das ändern?"
 msgid "Do you like this comment?"
 msgstr "Gefällt dir dieser Kommentar?"
 
-#: templates/django_comments_xtd/like.html:59
+#: templates/django_comments_xtd/like.html:60
 msgid ""
 "Click on the \"withdraw\" button if you want to withdraw your positive "
 "opinion on this comment."
@@ -293,7 +393,7 @@ msgstr ""
 "Klick auf den „Zurückziehen“-Button, wenn du deine Mainung zu diesem "
 "Kommentar zurückziehen möchtest."
 
-#: templates/django_comments_xtd/like.html:70
+#: templates/django_comments_xtd/like.html:71
 msgid "I like it"
 msgstr "Ich mag ihn."
 
@@ -347,6 +447,22 @@ msgstr "Kommentar-Reihe wurde leise geschaltet"
 msgid "You will no longer receive email notifications for comments sent to"
 msgstr "Du erhältst keine e-Mail Benachrichtigungen mehr für:"
 
+#: templates/django_comments_xtd/only_users_can_post.html:5
+msgid "Only registered users can post comments."
+msgstr "Nur registrierte Benutzer können Kommentare abgeben."
+
+#: templates/django_comments_xtd/removal_notification_email.txt:1
+msgid "A removal suggestion has been received for the following comment:"
+msgstr "Für den folgenden Kommentar ist ein Vorschlag zur Entfernung eingegangen:"
+
+#: templates/django_comments_xtd/removal_notification_email.txt:7
+msgid "Posted to the following URL"
+msgstr "Veröffentlicht unter der folgenden URL"
+
+#: templates/django_comments_xtd/removal_notification_email.txt:10
+msgid "Removal suggested by"
+msgstr "Entfernung vorgeschlagen von"
+
 #: templates/django_comments_xtd/reply.html:6
 msgid "Comment reply"
 msgstr "Antwort"
@@ -355,10 +471,29 @@ msgstr "Antwort"
 msgid "Reply to comment"
 msgstr "Kommentar beantworten"
 
-#: views.py:49
+#: tests/apiauth.py:17
+msgid "Invalid token header. No credentials provided."
+msgstr "Ungültiger Token-Header. Keine Anmeldeinformationen angegeben."
+
+#: tests/apiauth.py:20
+msgid "Invalid token header.Token string should not contain spaces."
+msgstr "Ungültiger Token-Header: Token-String darf keine Leerzeichen enthalten."
+
+#: tests/apiauth.py:27
+msgid ""
+"Invalid token header. Token string should not contain invalid characters."
+msgstr "Ungültiger Token-Header. Token-String sollte keine ungültigen Zeichen enthalten."
+
+#: views.py:60
 msgid "comment confirmation request"
 msgstr "Anfrage einer Bestätigung"
 
-#: views.py:212
+#: views.py:278
 msgid "new comment posted"
 msgstr "Ein neuer Kommentar wurde gepostet."
+
+#~ msgid "Submitted by"
+#~ msgstr "Eingereicht von"
+
+#~ msgid "Kind regards,"
+#~ msgstr "Freundliche Grüße,"

--- a/django_comments_xtd/locale/es/LC_MESSAGES/django.po
+++ b/django_comments_xtd/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-20 15:26+0200\n"
+"POT-Creation-Date: 2022-09-17 23:38+0200\n"
 "PO-Revision-Date: 2017-09-20 15:30+0053\n"
 "Last-Translator: b'Administrator  <admin@example.com>'\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.7.13\n"
 
-#: api/serializers.py:188
+#: api/serializers.py:277 templates/comments/list.html:17
+#: templates/django_comments_xtd/comment.html:15
+#: templates/django_comments_xtd/comment_tree.html:36
 msgid "This comment has been removed."
 msgstr "Este comentario ha sido suprimido."
 
@@ -27,261 +29,494 @@ msgstr "Este comentario ha sido suprimido."
 msgid "Notify me about follow-up comments"
 msgstr "Notifíqueme subsiguientes comentarios"
 
-#: forms.py:28
+#: forms.py:29
 msgid "Name"
 msgstr "Nombre"
 
-#: forms.py:29
+#: forms.py:31
 msgid "name"
 msgstr "nombre"
 
-#: forms.py:32
+#: forms.py:33
 msgid "Mail"
 msgstr "Correo"
 
-#: forms.py:32
+#: forms.py:34
 msgid "Required for comment verification"
 msgstr "Necesario para verificar el comentario."
 
-#: forms.py:33
+#: forms.py:36
 msgid "mail address"
 msgstr "dirección de correo"
 
-#: forms.py:36
+#: forms.py:38
 msgid "Link"
 msgstr "Enlace"
 
-#: forms.py:38
+#: forms.py:41
 msgid "url your name links to (optional)"
 msgstr "url al que enlazar su nombre (opcional)"
 
-#: forms.py:41
+#: forms.py:45
 msgid "Your comment"
 msgstr "Su comentario"
 
-#: models.py:69
+#: models.py:68
 msgid "Notify follow-up comments"
 msgstr "Notificar subsiguientes comentarios"
 
-#: views.py:48
+#: templates/404.html:9
+msgid "Page not found"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:1
+msgid "A new comment has been sent to the following URL:"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:5
+#: templates/django_comments_xtd/email_followup_comment.html:5
+#: templates/django_comments_xtd/email_followup_comment.txt:8
+msgid "Sent by"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:6
+#, fuzzy
+#| msgid "mail address"
+msgid "Email address"
+msgstr "dirección de correo"
+
+#: templates/comments/comment_notification_email.txt:8
+#: templates/django_comments_xtd/email_confirmation_request.txt:7
+#: templates/django_comments_xtd/email_followup_comment.txt:10
+#: templates/django_comments_xtd/removal_notification_email.txt:3
+#, fuzzy
+#| msgid "Comment reply"
+msgid "Comment"
+msgstr "Responder comentario"
+
+#: templates/comments/delete.html:5
+msgid "Remove comment"
+msgstr "Suprimir comentario"
+
+#: templates/comments/delete.html:9
+msgid "Remove this comment?"
+msgstr "¿Suprimir este comentario?"
+
+#: templates/comments/delete.html:12
+msgid ""
+"As a moderator you can delete comments. Deleting a comment does not remove "
+"it from the site, only prevents your website from showing the text. Click on "
+"the remove button to delete the following comment:"
+msgstr ""
+"Como moderador puede suprimir comentarios. Suprimir un comentario no lo "
+"elimina o borra de la web, solo evita que sea mostrado. Haga clic en el "
+"botón de suprimir para suprimir el siguiente comentario:  "
+
+#: templates/comments/delete.html:45
+msgid "Remove"
+msgstr "Suprimir"
+
+#: templates/comments/delete.html:46 templates/comments/flag.html:57
+#: templates/django_comments_xtd/dislike.html:74
+#: templates/django_comments_xtd/like.html:73
+msgid "cancel"
+msgstr "cancelar"
+
+#: templates/comments/deleted.html:5
+msgid "Comment removed"
+msgstr "Comentario suprimido"
+
+#: templates/comments/deleted.html:12
+msgid "The comment has been removed."
+msgstr "El comentario ha sido suprimido."
+
+#: templates/comments/deleted.html:13 templates/comments/flagged.html:13
+msgid ""
+"Thank you for taking the time to improve the quality of discussion in our "
+"site."
+msgstr ""
+"Gracias por el tiempo dedicado a mejorar la calidad del contenido en la web."
+
+#: templates/comments/flag.html:5
+msgid "Flag comment"
+msgstr "Marcar como inadecuado"
+
+#: templates/comments/flag.html:13
+msgid "Flag this comment?"
+msgstr "¿Marcar comentario como inadecuado?"
+
+#: templates/comments/flag.html:16
+msgid ""
+"Click on the flag button to mark the following comment as inappropriate."
+msgstr ""
+"Haga clic en el botón Marcar para indicar que el contenido del comentario es "
+"inadecuado."
+
+#: templates/comments/flag.html:41
+#: templates/django_comments_xtd/comment.html:11
+#: templates/django_comments_xtd/dislike.html:49
+#: templates/django_comments_xtd/like.html:47
+msgid "Posted to "
+msgstr "Enviado a"
+
+#: templates/comments/flag.html:56
+msgid "Flag"
+msgstr "Marcar"
+
+#: templates/comments/flagged.html:5
+msgid "Comment flagged"
+msgstr "Comentario marcado"
+
+#: templates/comments/flagged.html:12
+msgid "The comment has been flagged."
+msgstr "El comentario ha sido marcado como inadecuado."
+
+#: templates/comments/form.html:70
+msgid "send"
+msgstr ""
+
+#: templates/comments/form.html:71
+msgid "preview"
+msgstr ""
+
+#: templates/comments/list.html:25
+#: templates/django_comments_xtd/comment_tree.html:45
+msgid "Reply"
+msgstr "Responder"
+
+#: templates/comments/posted.html:6
+msgid "Comment confirmation requested."
+msgstr "Confirmación de comentario solicitada. "
+
+#: templates/comments/posted.html:12
+#, fuzzy
+#| msgid ""
+#| "A confirmation message has been sent to your\n"
+#| "  email address. Please, click on the link in the message to confirm\n"
+#| "  your comment."
+msgid ""
+"A confirmation message has been sent to your\n"
+"            email address. Please, click on the link in the message to "
+"confirm\n"
+"            your comment."
+msgstr ""
+"Se le ha enviado un correo para confirmar el comentario. Por favor, haga "
+"clic en el enlace del mensaje para confirmar su comentario."
+
+#: templates/comments/posted.html:17
+msgid "Go back to"
+msgstr ""
+
+#: templates/comments/preview.html:5 templates/comments/preview.html:10
+msgid "Preview your comment"
+msgstr "Comentario en vista previa"
+
+#: templates/comments/preview.html:14
+#, fuzzy
+#| msgid "Preview your comment for:"
+msgid "Preview of your comment for:"
+msgstr "Revise su comentario a"
+
+#: templates/comments/preview.html:21
+msgid "Empty comment."
+msgstr "Comentario vacío."
+
+#: templates/comments/preview.html:48
+#: templates/django_comments_xtd/reply.html:32
+#, fuzzy
+#| msgid "Your comment"
+msgid "Post your comment"
+msgstr "Su comentario"
+
+#: templates/django_comments_xtd/comment_list.html:11
+msgid "List of comments"
+msgstr "Lista de comentarios"
+
+#: templates/django_comments_xtd/comment_list.html:21
+#, fuzzy
+#| msgid "Your comment"
+msgid "No comments yet."
+msgstr "Su comentario"
+
+#: templates/django_comments_xtd/comment_tree.html:12
+msgid "moderator"
+msgstr "moderador"
+
+#: templates/django_comments_xtd/comment_tree.html:12
+msgid "comment permalink"
+msgstr "enlace permanente"
+
+#: templates/django_comments_xtd/comment_tree.html:17
+#, python-format
+msgid "A user has flagged this comment as inappropriate."
+msgid_plural "%(counter)s users have flagged this comment as inappropriate."
+msgstr[0] "Un usuario ha marcado este comentario como inadecuado."
+msgstr[1] "%(counter)s usuarios han marcado este comentario como inadecuado."
+
+#: templates/django_comments_xtd/comment_tree.html:21
+msgid "comment flagged"
+msgstr "comentario inadecuado"
+
+#: templates/django_comments_xtd/comment_tree.html:25
+msgid "flag comment"
+msgstr "marcar inadecuado"
+
+#: templates/django_comments_xtd/comment_tree.html:30
+msgid "remove comment"
+msgstr "suprimir comentario"
+
+#: templates/django_comments_xtd/discarded.html:4
+msgid "Comment discarded"
+msgstr "Comentario descartado"
+
+#: templates/django_comments_xtd/discarded.html:7
+msgid "Comment automatically discarded"
+msgstr "Comentario descartado automáticamente"
+
+#: templates/django_comments_xtd/discarded.html:8
+msgid "Sorry, your comment has been automatically discarded"
+msgstr "Lo sentimos, su comentario ha sido descartado automáticamente"
+
+#: templates/django_comments_xtd/dislike.html:5
+#: templates/django_comments_xtd/like.html:5
+msgid "Confirm your opinion"
+msgstr "Confirme su opinión"
+
+#: templates/django_comments_xtd/dislike.html:15
+msgid "You didn't like this comment, do you want to change it?"
+msgstr "No le había gustado este comentario, ¿Desea cambiar de opinión?"
+
+#: templates/django_comments_xtd/dislike.html:17
+msgid "Do you dislike this comment?"
+msgstr "¿No le gusta este comentario?"
+
+#: templates/django_comments_xtd/dislike.html:22
+#: templates/django_comments_xtd/like.html:22
+msgid "Please, confirm your opinion about the comment."
+msgstr "Por favor, confirme su opinión sobre este comentario."
+
+#: templates/django_comments_xtd/dislike.html:62
+msgid ""
+"Click on the \"withdraw\" button if you want to withdraw your negative "
+"opinion on this comment."
+msgstr ""
+"Haga click en el botón \"retirar\" si quiere cambiar su opinión negativa "
+"sobre este comentario."
+
+#: templates/django_comments_xtd/dislike.html:70
+#: templates/django_comments_xtd/like.html:69
+msgid "Withdraw"
+msgstr "Retirar"
+
+#: templates/django_comments_xtd/dislike.html:72
+msgid "I dislike it"
+msgstr "No me gusta"
+
+#: templates/django_comments_xtd/disliked.html:4
+msgid "You disliked the comment"
+msgstr "No le gusta este comentario"
+
+#: templates/django_comments_xtd/disliked.html:7
+#: templates/django_comments_xtd/liked.html:7
+msgid "Thanks for taking the time to participate."
+msgstr "Muchas gracias por participar."
+
+#: templates/django_comments_xtd/email_confirmation_request.html:3
+#: templates/django_comments_xtd/email_confirmation_request.txt:3
+msgid ""
+"You or someone in behalf of you have requested to post a comment into this "
+"page:"
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:7
+#: templates/django_comments_xtd/email_followup_comment.html:8
+#, fuzzy
+#| msgid "Remove comment"
+msgid "The comment"
+msgstr "Suprimir comentario"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:11
+#: templates/django_comments_xtd/email_confirmation_request.txt:11
+#, python-format
+msgid ""
+"If you do not wish to post the comment, please ignore this message or report "
+"an incident to %(contact)s. Otherwise click on the link below to confirm the "
+"comment."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:15
+#: templates/django_comments_xtd/email_confirmation_request.txt:15
+msgid ""
+"If clicking does not work, you can also copy and paste the address into your "
+"browser's address window."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:17
+#: templates/django_comments_xtd/email_confirmation_request.txt:16
+#, fuzzy
+#| msgid "Thanks for removing"
+msgid "Thanks for your comment!"
+msgstr "Gracias por suprimir "
+
+#: templates/django_comments_xtd/email_confirmation_request.html:19
+#: templates/django_comments_xtd/email_confirmation_request.txt:19
+#: templates/django_comments_xtd/email_followup_comment.html:14
+#: templates/django_comments_xtd/email_followup_comment.txt:20
+msgid "Kind regards"
+msgstr "Un cordial saludo"
+
+#: templates/django_comments_xtd/email_followup_comment.html:3
+#: templates/django_comments_xtd/email_followup_comment.txt:4
+msgid "There is a new comment following up yours."
+msgstr "Se ha recibido un nuevo comentario después del suyo."
+
+#: templates/django_comments_xtd/email_followup_comment.html:12
+#, python-format
+msgid ""
+"Click <a href=\"http://%(site_domain)s%(mute_url)s\">http://%(site_domain)s"
+"%(mute_url_short)s...</a> to mute the comments thread. You will no longer "
+"receive follow-up notifications."
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:6
+msgid "Post"
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:15
+msgid ""
+"Click on the following link to mute the comments thread. You will no longer "
+"receive follow-up notifications:"
+msgstr ""
+
+#: templates/django_comments_xtd/like.html:15
+msgid "You liked this comment, do you want to change it?"
+msgstr "Le había gustado este comentario, ¿Quiere cambiar de opinión?"
+
+#: templates/django_comments_xtd/like.html:17
+msgid "Do you like this comment?"
+msgstr "¿Le ha gustado este comentario?"
+
+#: templates/django_comments_xtd/like.html:60
+msgid ""
+"Click on the \"withdraw\" button if you want to withdraw your positive "
+"opinion on this comment."
+msgstr ""
+"Haga clic en el botón \"retirar\" si quiere cambiar su opinión negativa "
+"sobre este comentario."
+
+#: templates/django_comments_xtd/like.html:71
+msgid "I like it"
+msgstr "Me gusta"
+
+#: templates/django_comments_xtd/liked.html:4
+msgid "Your opinion is appreciated"
+msgstr "Le agradecemos su opinión"
+
+#: templates/django_comments_xtd/moderated.html:4
+msgid "Comment requires approval"
+msgstr "El comentario necesita ser aprobado"
+
+#: templates/django_comments_xtd/moderated.html:8
+msgid "Comment in moderation"
+msgstr "Comentario en moderación"
+
+#: templates/django_comments_xtd/moderated.html:14
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "  Your comment is in moderation.<br/>\n"
+#| "  It has to be reviewed before being published.<br/>\n"
+#| "  Thank you for your patience and understanding.\n"
+#| "  "
+msgid ""
+"\n"
+"            Your comment is in moderation.<br/>\n"
+"            It has to be reviewed before being published.<br/>\n"
+"            Thank you for your patience and understanding.\n"
+"            "
+msgstr ""
+"\n"
+"Su comentario esta en moderación.<br/>\n"
+"Necesita ser revisado antes de ser publicado.<br/>\n"
+"Gracias por su paciencia y comprensión."
+
+#: templates/django_comments_xtd/moderated.html:22
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "  Go back to <a href=\"%(content_object_url)s\">%(content_object_str)s</"
+#| "a>\n"
+#| "  "
+msgid ""
+"\n"
+"            Go back to: <a href=\"%(content_object_url)s\">"
+"%(content_object_str)s</a>\n"
+"            "
+msgstr ""
+"\n"
+"Volver a <a href=\"%(content_object_url)s\">%(content_object_str)s</a>"
+
+#: templates/django_comments_xtd/muted.html:4
+msgid "Comment thread muted"
+msgstr "Hilo de comentarios silenciado"
+
+#: templates/django_comments_xtd/muted.html:7
+msgid "Comment thread has been muted"
+msgstr "El hilo de comentarios ha sido silenciado"
+
+#: templates/django_comments_xtd/muted.html:9
+msgid "You will no longer receive email notifications for comments sent to"
+msgstr "No recibirá más notificaciones de comentarios enviados a"
+
+#: templates/django_comments_xtd/only_users_can_post.html:5
+msgid "Only registered users can post comments."
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:1
+msgid "A removal suggestion has been received for the following comment:"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:7
+msgid "Posted to the following URL"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:10
+msgid "Removal suggested by"
+msgstr ""
+
+#: templates/django_comments_xtd/reply.html:6
+msgid "Comment reply"
+msgstr "Responder comentario"
+
+#: templates/django_comments_xtd/reply.html:11
+msgid "Reply to comment"
+msgstr "Respuesta al comentario"
+
+#: tests/apiauth.py:17
+msgid "Invalid token header. No credentials provided."
+msgstr ""
+
+#: tests/apiauth.py:20
+msgid "Invalid token header.Token string should not contain spaces."
+msgstr ""
+
+#: tests/apiauth.py:27
+msgid ""
+"Invalid token header. Token string should not contain invalid characters."
+msgstr ""
+
+#: views.py:60
 msgid "comment confirmation request"
 msgstr "confirmar comentario "
 
-#: views.py:209
+#: views.py:278
 msgid "new comment posted"
 msgstr "recibido nuevo comentario"
 
-#~ msgid "Remove comment"
-#~ msgstr "Suprimir comentario"
-
-#~ msgid "Remove this comment?"
-#~ msgstr "¿Suprimir este comentario?"
-
-#~ msgid ""
-#~ "As a moderator you can delete comments. Deleting a comment does not remove "
-#~ "it from the site, only prevents your website from showing the text. Click on"
-#~ " the remove button to delete the following comment:"
-#~ msgstr ""
-#~ "Como moderador puede suprimir comentarios. Suprimir un comentario no lo "
-#~ "elimina o borra de la web, solo evita que sea mostrado. Haga clic en el "
-#~ "botón de suprimir para suprimir el siguiente comentario:  "
-
-#~ msgid "Remove"
-#~ msgstr "Suprimir"
-
-#~ msgid "Comment removed"
-#~ msgstr "Comentario suprimido"
-
-#~ msgid "The comment has been removed."
-#~ msgstr "El comentario ha sido suprimido."
-
-#~ msgid ""
-#~ "Thank you for taking the time to improve the quality of discussion in our "
-#~ "site."
-#~ msgstr ""
-#~ "Gracias por el tiempo dedicado a mejorar la calidad del contenido en la web."
-
-#~ msgid "Flag comment"
-#~ msgstr "Marcar como inadecuado"
-
-#~ msgid "Flag this comment?"
-#~ msgstr "¿Marcar comentario como inadecuado?"
-
-#~ msgid ""
-#~ "Click on the flag button to mark the following comment as inappropriate."
-#~ msgstr ""
-#~ "Haga clic en el botón Marcar para indicar que el contenido del comentario es"
-#~ " inadecuado."
-
-#~ msgid "Posted to "
-#~ msgstr "Enviado a"
-
-#~ msgid "Flag"
-#~ msgstr "Marcar"
-
-#~ msgid "cancel"
-#~ msgstr "cancelar"
-
-#~ msgid "Comment flagged"
-#~ msgstr "Comentario marcado"
-
-#~ msgid "The comment has been flagged."
-#~ msgstr "El comentario ha sido marcado como inadecuado."
-
-#~ msgid "Reply"
-#~ msgstr "Responder"
-
-#~ msgid "Comment confirmation requested."
-#~ msgstr "Confirmación de comentario solicitada. "
-
-#~ msgid ""
-#~ "A confirmation message has been sent to your\n"
-#~ "  email address. Please, click on the link in the message to confirm\n"
-#~ "  your comment."
-#~ msgstr ""
-#~ "Se le ha enviado un correo para confirmar el comentario. Por favor, haga "
-#~ "clic en el enlace del mensaje para confirmar su comentario."
-
-#~ msgid "Preview your comment"
-#~ msgstr "Comentario en vista previa"
-
-#~ msgid "Preview your comment for:"
-#~ msgstr "Revise su comentario a"
-
-#~ msgid "Empty comment."
-#~ msgstr "Comentario vacío."
-
-#~ msgid "List of comments"
-#~ msgstr "Lista de comentarios"
-
-#~ msgid "moderator"
-#~ msgstr "moderador"
-
-#~ msgid "comment permalink"
-#~ msgstr "enlace permanente"
-
-#~ msgid "comment flagged"
-#~ msgstr "comentario inadecuado"
-
-#~ msgid "flag comment"
-#~ msgstr "marcar inadecuado"
-
-#~ msgid "remove comment"
-#~ msgstr "suprimir comentario"
-
-#~ msgid "A user has flagged this comment as inappropriate."
-#~ msgid_plural "%(counter)s users have flagged this comment as inappropriate."
-#~ msgstr[0] "Un usuario ha marcado este comentario como inadecuado."
-#~ msgstr[1] "%(counter)s usuarios han marcado este comentario como inadecuado."
-
-#~ msgid "Comment discarded"
-#~ msgstr "Comentario descartado"
-
-#~ msgid "Comment automatically discarded"
-#~ msgstr "Comentario descartado automáticamente"
-
-#~ msgid "Sorry, your comment has been automatically discarded"
-#~ msgstr "Lo sentimos, su comentario ha sido descartado automáticamente"
-
-#~ msgid "Confirm your opinion"
-#~ msgstr "Confirme su opinión"
-
-#~ msgid "You didn't like this comment, do you want to change it?"
-#~ msgstr "No le había gustado este comentario, ¿Desea cambiar de opinión?"
-
-#~ msgid "Do you dislike this comment?"
-#~ msgstr "¿No le gusta este comentario?"
-
-#~ msgid "Please, confirm your opinion about the comment."
-#~ msgstr "Por favor, confirme su opinión sobre este comentario."
-
-#~ msgid ""
-#~ "Click on the \"withdraw\" button if you want to withdraw your negative "
-#~ "opinion on this comment."
-#~ msgstr ""
-#~ "Haga click en el botón \"retirar\" si quiere cambiar su opinión negativa "
-#~ "sobre este comentario."
-
-#~ msgid "Withdraw"
-#~ msgstr "Retirar"
-
-#~ msgid "I dislike it"
-#~ msgstr "No me gusta"
-
-#~ msgid "You disliked the comment"
-#~ msgstr "No le gusta este comentario"
-
-#~ msgid "Thanks for taking the time to participate."
-#~ msgstr "Muchas gracias por participar."
-
-#~ msgid "There is a new comment following up yours."
-#~ msgstr "Se ha recibido un nuevo comentario después del suyo."
-
-#~ msgid "Kind regards"
+#, fuzzy
+#~| msgid "Kind regards"
+#~ msgid "Kind regards,"
 #~ msgstr "Un cordial saludo"
-
-#~ msgid "You liked this comment, do you want to change it?"
-#~ msgstr "Le había gustado este comentario, ¿Quiere cambiar de opinión?"
-
-#~ msgid "Do you like this comment?"
-#~ msgstr "¿Le ha gustado este comentario?"
-
-#~ msgid ""
-#~ "Click on the \"withdraw\" button if you want to withdraw your positive "
-#~ "opinion on this comment."
-#~ msgstr ""
-#~ "Haga clic en el botón \"retirar\" si quiere cambiar su opinión negativa "
-#~ "sobre este comentario."
-
-#~ msgid "I like it"
-#~ msgstr "Me gusta"
-
-#~ msgid "Your opinion is appreciated"
-#~ msgstr "Le agradecemos su opinión"
-
-#~ msgid "Comment requires approval"
-#~ msgstr "El comentario necesita ser aprobado"
-
-#~ msgid "Comment in moderation"
-#~ msgstr "Comentario en moderación"
-
-#~ msgid ""
-#~ "\n"
-#~ "  Your comment is in moderation.<br/>\n"
-#~ "  It has to be reviewed before being published.<br/>\n"
-#~ "  Thank you for your patience and understanding.\n"
-#~ "  "
-#~ msgstr ""
-#~ "\n"
-#~ "Su comentario esta en moderación.<br/>\n"
-#~ "Necesita ser revisado antes de ser publicado.<br/>\n"
-#~ "Gracias por su paciencia y comprensión."
-
-#~ msgid ""
-#~ "\n"
-#~ "  Go back to <a href=\"%(content_object_url)s\">%(content_object_str)s</a>\n"
-#~ "  "
-#~ msgstr ""
-#~ "\n"
-#~ "Volver a <a href=\"%(content_object_url)s\">%(content_object_str)s</a>"
-
-#~ msgid "Comment thread muted"
-#~ msgstr "Hilo de comentarios silenciado"
-
-#~ msgid "Comment thread has been muted"
-#~ msgstr "El hilo de comentarios ha sido silenciado"
-
-#~ msgid "You will no longer receive email notifications for comments sent to"
-#~ msgstr "No recibirá más notificaciones de comentarios enviados a"
-
-#~ msgid "Comment reply"
-#~ msgstr "Responder comentario"
-
-#~ msgid "Reply to comment"
-#~ msgstr "Respuesta al comentario"
 
 #~ msgid "Thank you, the comment has been removed."
 #~ msgstr "Gracias, el comentario ha sido suprimido."
-
-#~ msgid "Thanks for removing"
-#~ msgstr "Gracias por suprimir "

--- a/django_comments_xtd/locale/fi/LC_MESSAGES/django.po
+++ b/django_comments_xtd/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-22 16:28+0300\n"
+"POT-Creation-Date: 2022-09-17 23:38+0200\n"
 "PO-Revision-Date: 2017-09-22 15:12+0053\n"
 "Last-Translator: b'Administrator  <admin@example.com>'\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,9 +19,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.7.13\n"
 
-#: api/serializers.py:188 templates/comments/list.html:16
+#: api/serializers.py:277 templates/comments/list.html:17
 #: templates/django_comments_xtd/comment.html:15
-#: templates/django_comments_xtd/comment_tree.html:33
+#: templates/django_comments_xtd/comment_tree.html:36
 msgid "This comment has been removed."
 msgstr "Tämä kommentti on poistettu"
 
@@ -29,51 +29,80 @@ msgstr "Tämä kommentti on poistettu"
 msgid "Notify me about follow-up comments"
 msgstr "Ilmoita minulle uusista kommenteista"
 
-#: forms.py:28
+#: forms.py:29
 msgid "Name"
 msgstr ""
 
-#: forms.py:29
+#: forms.py:31
 msgid "name"
 msgstr "nimi"
 
-#: forms.py:32
+#: forms.py:33
 msgid "Mail"
 msgstr "Sähköposti"
 
-#: forms.py:32
+#: forms.py:34
 msgid "Required for comment verification"
 msgstr "Tarvitaan kommentin vahvistukseen"
 
-#: forms.py:33
+#: forms.py:36
 msgid "mail address"
 msgstr "sähköpostiosoite"
 
-#: forms.py:36
+#: forms.py:38
 msgid "Link"
 msgstr "Linkki"
 
-#: forms.py:38
+#: forms.py:41
 msgid "url your name links to (optional)"
 msgstr "verkko-osoite johon nimimerkkisi linkitetään (vapaaehtoinen)"
 
-#: forms.py:41
+#: forms.py:45
 msgid "Your comment"
 msgstr "Kommenttisi"
 
-#: models.py:69
+#: models.py:68
 msgid "Notify follow-up comments"
 msgstr "Ilmoita jatkokommenteista"
+
+#: templates/404.html:9
+msgid "Page not found"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:1
+msgid "A new comment has been sent to the following URL:"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:5
+#: templates/django_comments_xtd/email_followup_comment.html:5
+#: templates/django_comments_xtd/email_followup_comment.txt:8
+msgid "Sent by"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:6
+#, fuzzy
+#| msgid "mail address"
+msgid "Email address"
+msgstr "sähköpostiosoite"
+
+#: templates/comments/comment_notification_email.txt:8
+#: templates/django_comments_xtd/email_confirmation_request.txt:7
+#: templates/django_comments_xtd/email_followup_comment.txt:10
+#: templates/django_comments_xtd/removal_notification_email.txt:3
+#, fuzzy
+#| msgid "Comment reply"
+msgid "Comment"
+msgstr "Vastaus kommenttiin"
 
 #: templates/comments/delete.html:5
 msgid "Remove comment"
 msgstr "Poista kommentti"
 
-#: templates/comments/delete.html:14
+#: templates/comments/delete.html:9
 msgid "Remove this comment?"
 msgstr "Poistetaanko tämä kommentti?"
 
-#: templates/comments/delete.html:15
+#: templates/comments/delete.html:12
 msgid ""
 "As a moderator you can delete comments. Deleting a comment does not remove "
 "it from the site, only prevents your website from showing the text. Click on "
@@ -83,9 +112,15 @@ msgstr ""
 "sitä muistista, sitä ei vain näytetä käyttäjille. Klikkaa poistopainiketta "
 "piilottaaksesi tämän kommentin:"
 
-#: templates/comments/delete.html:51
+#: templates/comments/delete.html:45
 msgid "Remove"
 msgstr "Poista"
+
+#: templates/comments/delete.html:46 templates/comments/flag.html:57
+#: templates/django_comments_xtd/dislike.html:74
+#: templates/django_comments_xtd/like.html:73
+msgid "cancel"
+msgstr "peruuta"
 
 #: templates/comments/deleted.html:5
 msgid "Comment removed"
@@ -105,32 +140,26 @@ msgstr "Kiitos että käytit aikaasi keskustelun tason parantamiseen."
 msgid "Flag comment"
 msgstr "Merkkaa kommentti"
 
-#: templates/comments/flag.html:12
+#: templates/comments/flag.html:13
 msgid "Flag this comment?"
 msgstr "Merkataanko tämä kommentti?"
 
-#: templates/comments/flag.html:13
+#: templates/comments/flag.html:16
 msgid ""
 "Click on the flag button to mark the following comment as inappropriate."
 msgstr ""
 "Merkkauspainikkeella voit ilmoittaa seuraavan kommentin sopimattomaksi."
 
-#: templates/comments/flag.html:43
+#: templates/comments/flag.html:41
 #: templates/django_comments_xtd/comment.html:11
-#: templates/django_comments_xtd/dislike.html:47
+#: templates/django_comments_xtd/dislike.html:49
 #: templates/django_comments_xtd/like.html:47
 msgid "Posted to "
 msgstr "Kommentin kohde"
 
-#: templates/comments/flag.html:58
+#: templates/comments/flag.html:56
 msgid "Flag"
 msgstr "Merkkaa"
-
-#: templates/comments/flag.html:59
-#: templates/django_comments_xtd/dislike.html:73
-#: templates/django_comments_xtd/like.html:73
-msgid "cancel"
-msgstr "peruuta"
 
 #: templates/comments/flagged.html:5
 msgid "Comment flagged"
@@ -140,66 +169,99 @@ msgstr "Merkattu kommentti"
 msgid "The comment has been flagged."
 msgstr "Kommentti on merkattu"
 
-#: templates/comments/list.html:23
-#: templates/django_comments_xtd/comment_tree.html:42
+#: templates/comments/form.html:70
+msgid "send"
+msgstr ""
+
+#: templates/comments/form.html:71
+msgid "preview"
+msgstr ""
+
+#: templates/comments/list.html:25
+#: templates/django_comments_xtd/comment_tree.html:45
 msgid "Reply"
 msgstr "Vastaa"
 
-#: templates/comments/posted.html:5
+#: templates/comments/posted.html:6
 msgid "Comment confirmation requested."
 msgstr "Kommentin vahvistusta pyydetty"
 
-#: templates/comments/posted.html:7
+#: templates/comments/posted.html:12
+#, fuzzy
+#| msgid ""
+#| "A confirmation message has been sent to your\n"
+#| "  email address. Please, click on the link in the message to confirm\n"
+#| "  your comment."
 msgid ""
 "A confirmation message has been sent to your\n"
-"  email address. Please, click on the link in the message to confirm\n"
-"  your comment."
+"            email address. Please, click on the link in the message to "
+"confirm\n"
+"            your comment."
 msgstr ""
 "Vahvistusviesti on lähetetty sähköpostiosoitteeseesi. Ole hyvä ja klikkaa "
 "sähköpostissa olevaa linkkiä kommentin julkaisua varten."
 
-#: templates/comments/preview.html:5 templates/comments/preview.html:9
+#: templates/comments/posted.html:17
+msgid "Go back to"
+msgstr ""
+
+#: templates/comments/preview.html:5 templates/comments/preview.html:10
 msgid "Preview your comment"
 msgstr "Esikatsele kommenttiasi"
 
-#: templates/comments/preview.html:11
-msgid "Preview your comment for:"
+#: templates/comments/preview.html:14
+#, fuzzy
+#| msgid "Preview your comment for:"
+msgid "Preview of your comment for:"
 msgstr "Esikatsele vastaustasi:"
 
-#: templates/comments/preview.html:22
+#: templates/comments/preview.html:21
 msgid "Empty comment."
 msgstr "Tyhjä kommentti."
 
-#: templates/django_comments_xtd/comment_list.html:8
+#: templates/comments/preview.html:48
+#: templates/django_comments_xtd/reply.html:32
+#, fuzzy
+#| msgid "Your comment"
+msgid "Post your comment"
+msgstr "Kommenttisi"
+
+#: templates/django_comments_xtd/comment_list.html:11
 msgid "List of comments"
 msgstr "Kommenttilista"
 
-#: templates/django_comments_xtd/comment_tree.html:14
+#: templates/django_comments_xtd/comment_list.html:21
+#, fuzzy
+#| msgid "Your comment"
+msgid "No comments yet."
+msgstr "Kommenttisi"
+
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "moderator"
 msgstr "moderaattori"
 
-#: templates/django_comments_xtd/comment_tree.html:14
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "comment permalink"
 msgstr "kommentin linkki"
 
-#: templates/django_comments_xtd/comment_tree.html:18
-msgid "comment flagged"
-msgstr "kommentti merkattu"
-
-#: templates/django_comments_xtd/comment_tree.html:21
-msgid "flag comment"
-msgstr "merkkaa kommentti"
-
-#: templates/django_comments_xtd/comment_tree.html:24
-msgid "remove comment"
-msgstr "poista kommentti"
-
-#: templates/django_comments_xtd/comment_tree.html:26
+#: templates/django_comments_xtd/comment_tree.html:17
 #, python-format
 msgid "A user has flagged this comment as inappropriate."
 msgid_plural "%(counter)s users have flagged this comment as inappropriate."
 msgstr[0] "Yksi käyttäjä on merkannut tämän kommentin sopimattomaksi"
 msgstr[1] "%(counter)s käyttäjää on merkannut tämän kommentin sopimattomaksi"
+
+#: templates/django_comments_xtd/comment_tree.html:21
+msgid "comment flagged"
+msgstr "kommentti merkattu"
+
+#: templates/django_comments_xtd/comment_tree.html:25
+msgid "flag comment"
+msgstr "merkkaa kommentti"
+
+#: templates/django_comments_xtd/comment_tree.html:30
+msgid "remove comment"
+msgstr "poista kommentti"
 
 #: templates/django_comments_xtd/discarded.html:4
 msgid "Comment discarded"
@@ -218,20 +280,20 @@ msgstr "Kommenttisi on automaattisesti hylätty"
 msgid "Confirm your opinion"
 msgstr "Vahvista kantasi"
 
-#: templates/django_comments_xtd/dislike.html:14
+#: templates/django_comments_xtd/dislike.html:15
 msgid "You didn't like this comment, do you want to change it?"
 msgstr "Et tykännyt tästä kommentista, haluatko vaihtaa kantaasi?"
 
-#: templates/django_comments_xtd/dislike.html:16
+#: templates/django_comments_xtd/dislike.html:17
 msgid "Do you dislike this comment?"
 msgstr "Etkö tykkää tästä kommentista?"
 
-#: templates/django_comments_xtd/dislike.html:19
-#: templates/django_comments_xtd/like.html:19
+#: templates/django_comments_xtd/dislike.html:22
+#: templates/django_comments_xtd/like.html:22
 msgid "Please, confirm your opinion about the comment."
 msgstr "Ole hyvä, vahvista kantasi tästä kommentista."
 
-#: templates/django_comments_xtd/dislike.html:60
+#: templates/django_comments_xtd/dislike.html:62
 msgid ""
 "Click on the \"withdraw\" button if you want to withdraw your negative "
 "opinion on this comment."
@@ -239,12 +301,12 @@ msgstr ""
 "Paina peru-painiketta jos haluat peruuttaa negatiivisen kantasi tästä "
 "kommentista."
 
-#: templates/django_comments_xtd/dislike.html:69
+#: templates/django_comments_xtd/dislike.html:70
 #: templates/django_comments_xtd/like.html:69
 msgid "Withdraw"
 msgstr "Peru"
 
-#: templates/django_comments_xtd/dislike.html:71
+#: templates/django_comments_xtd/dislike.html:72
 msgid "I dislike it"
 msgstr "En pidä"
 
@@ -257,19 +319,78 @@ msgstr "Et pitänyt tästä kommentista"
 msgid "Thanks for taking the time to participate."
 msgstr "Kiitos osallistumisestasi"
 
-#: templates/django_comments_xtd/email_followup_comment.txt:4
-msgid "There is a new comment following up yours."
-msgstr "Kommenttisi jälkeen on tullut uusi kommentti."
+#: templates/django_comments_xtd/email_confirmation_request.html:3
+#: templates/django_comments_xtd/email_confirmation_request.txt:3
+msgid ""
+"You or someone in behalf of you have requested to post a comment into this "
+"page:"
+msgstr ""
 
+#: templates/django_comments_xtd/email_confirmation_request.html:7
+#: templates/django_comments_xtd/email_followup_comment.html:8
+#, fuzzy
+#| msgid "Remove comment"
+msgid "The comment"
+msgstr "Poista kommentti"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:11
+#: templates/django_comments_xtd/email_confirmation_request.txt:11
+#, python-format
+msgid ""
+"If you do not wish to post the comment, please ignore this message or report "
+"an incident to %(contact)s. Otherwise click on the link below to confirm the "
+"comment."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:15
+#: templates/django_comments_xtd/email_confirmation_request.txt:15
+msgid ""
+"If clicking does not work, you can also copy and paste the address into your "
+"browser's address window."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:17
+#: templates/django_comments_xtd/email_confirmation_request.txt:16
+#, fuzzy
+#| msgid "Preview your comment"
+msgid "Thanks for your comment!"
+msgstr "Esikatsele kommenttiasi"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:19
+#: templates/django_comments_xtd/email_confirmation_request.txt:19
+#: templates/django_comments_xtd/email_followup_comment.html:14
 #: templates/django_comments_xtd/email_followup_comment.txt:20
 msgid "Kind regards"
 msgstr "Parhain terveisin"
 
-#: templates/django_comments_xtd/like.html:14
+#: templates/django_comments_xtd/email_followup_comment.html:3
+#: templates/django_comments_xtd/email_followup_comment.txt:4
+msgid "There is a new comment following up yours."
+msgstr "Kommenttisi jälkeen on tullut uusi kommentti."
+
+#: templates/django_comments_xtd/email_followup_comment.html:12
+#, python-format
+msgid ""
+"Click <a href=\"http://%(site_domain)s%(mute_url)s\">http://%(site_domain)s"
+"%(mute_url_short)s...</a> to mute the comments thread. You will no longer "
+"receive follow-up notifications."
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:6
+msgid "Post"
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:15
+msgid ""
+"Click on the following link to mute the comments thread. You will no longer "
+"receive follow-up notifications:"
+msgstr ""
+
+#: templates/django_comments_xtd/like.html:15
 msgid "You liked this comment, do you want to change it?"
 msgstr "Tykkäsit tästä kommentista, haluatko perua tykkäyksen?"
 
-#: templates/django_comments_xtd/like.html:16
+#: templates/django_comments_xtd/like.html:17
 msgid "Do you like this comment?"
 msgstr "Tykkäsitkö tästä kommentista?"
 
@@ -293,27 +414,40 @@ msgstr "Kiitos kannanotostasi"
 msgid "Comment requires approval"
 msgstr "Kommentti pitää hyväksyä"
 
-#: templates/django_comments_xtd/moderated.html:7
+#: templates/django_comments_xtd/moderated.html:8
 msgid "Comment in moderation"
 msgstr "Kommentti on hyväksyttävänä"
 
-#: templates/django_comments_xtd/moderated.html:9
+#: templates/django_comments_xtd/moderated.html:14
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "  Your comment is in moderation.<br/>\n"
+#| "  It has to be reviewed before being published.<br/>\n"
+#| "  Thank you for your patience and understanding.\n"
+#| "  "
 msgid ""
 "\n"
-"  Your comment is in moderation.<br/>\n"
-"  It has to be reviewed before being published.<br/>\n"
-"  Thank you for your patience and understanding.\n"
-"  "
+"            Your comment is in moderation.<br/>\n"
+"            It has to be reviewed before being published.<br/>\n"
+"            Thank you for your patience and understanding.\n"
+"            "
 msgstr ""
 "\n"
 "Kommenttisi on hyväksyttävänä. <br/>Se pitää tarkistaa ennen julkaisua"
 
-#: templates/django_comments_xtd/moderated.html:17
-#, python-format
+#: templates/django_comments_xtd/moderated.html:22
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "  Go back to <a href=\"%(content_object_url)s\">%(content_object_str)s</"
+#| "a>\n"
+#| "  "
 msgid ""
 "\n"
-"  Go back to <a href=\"%(content_object_url)s\">%(content_object_str)s</a>\n"
-"  "
+"            Go back to: <a href=\"%(content_object_url)s\">"
+"%(content_object_str)s</a>\n"
+"            "
 msgstr ""
 "\n"
 "Palaa takaisin <a href=\"%(content_object_url)s\">%(content_object_str)s</a>"
@@ -331,18 +465,52 @@ msgid "You will no longer receive email notifications for comments sent to"
 msgstr ""
 "Sinulle ei enää lähetetä sähköpostiherätteitä kommenteista jotka on lähetetty"
 
+#: templates/django_comments_xtd/only_users_can_post.html:5
+msgid "Only registered users can post comments."
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:1
+msgid "A removal suggestion has been received for the following comment:"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:7
+msgid "Posted to the following URL"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:10
+msgid "Removal suggested by"
+msgstr ""
+
 #: templates/django_comments_xtd/reply.html:6
 msgid "Comment reply"
 msgstr "Vastaus kommenttiin"
 
-#: templates/django_comments_xtd/reply.html:13
+#: templates/django_comments_xtd/reply.html:11
 msgid "Reply to comment"
 msgstr "Vastaa kommenttiin"
 
-#: views.py:48
+#: tests/apiauth.py:17
+msgid "Invalid token header. No credentials provided."
+msgstr ""
+
+#: tests/apiauth.py:20
+msgid "Invalid token header.Token string should not contain spaces."
+msgstr ""
+
+#: tests/apiauth.py:27
+msgid ""
+"Invalid token header. Token string should not contain invalid characters."
+msgstr ""
+
+#: views.py:60
 msgid "comment confirmation request"
 msgstr "kommentin vahvistuspyyntö"
 
-#: views.py:209
+#: views.py:278
 msgid "new comment posted"
 msgstr "uusi kommentti julkaistu"
+
+#, fuzzy
+#~| msgid "Kind regards"
+#~ msgid "Kind regards,"
+#~ msgstr "Parhain terveisin"

--- a/django_comments_xtd/locale/fr/LC_MESSAGES/django.po
+++ b/django_comments_xtd/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-20 15:32+0200\n"
+"POT-Creation-Date: 2022-09-17 23:38+0200\n"
 "PO-Revision-Date: 2017-09-20 15:32+0053\n"
 "Last-Translator: b'Administrator  <admin@example.com>'\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Translated-Using: django-rosetta 0.7.13\n"
 
-#: api/serializers.py:188
+#: api/serializers.py:277 templates/comments/list.html:17
+#: templates/django_comments_xtd/comment.html:15
+#: templates/django_comments_xtd/comment_tree.html:36
 msgid "This comment has been removed."
 msgstr "Ce commentaire a été supprimé."
 
@@ -27,258 +29,497 @@ msgstr "Ce commentaire a été supprimé."
 msgid "Notify me about follow-up comments"
 msgstr "Avertissez-moi des commentaires suivants"
 
-#: forms.py:28
+#: forms.py:29
 msgid "Name"
 msgstr "Nom"
 
-#: forms.py:29
+#: forms.py:31
 msgid "name"
 msgstr "nom"
 
-#: forms.py:32
+#: forms.py:33
 msgid "Mail"
 msgstr "Email"
 
-#: forms.py:32
+#: forms.py:34
 msgid "Required for comment verification"
 msgstr "Requis pour la vérification des commentaires"
 
-#: forms.py:33
+#: forms.py:36
 msgid "mail address"
 msgstr "adresse email"
 
-#: forms.py:36
+#: forms.py:38
 msgid "Link"
 msgstr "Lien"
 
-#: forms.py:38
+#: forms.py:41
 msgid "url your name links to (optional)"
 msgstr "Lien à afficher sur votre nom (optionnel)"
 
-#: forms.py:41
+#: forms.py:45
 msgid "Your comment"
 msgstr "Votre commentaire"
 
-#: models.py:69
+#: models.py:68
 msgid "Notify follow-up comments"
 msgstr "Avertir des commentaires suivants"
 
-#: views.py:48
+#: templates/404.html:9
+msgid "Page not found"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:1
+msgid "A new comment has been sent to the following URL:"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:5
+#: templates/django_comments_xtd/email_followup_comment.html:5
+#: templates/django_comments_xtd/email_followup_comment.txt:8
+msgid "Sent by"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:6
+#, fuzzy
+#| msgid "mail address"
+msgid "Email address"
+msgstr "adresse email"
+
+#: templates/comments/comment_notification_email.txt:8
+#: templates/django_comments_xtd/email_confirmation_request.txt:7
+#: templates/django_comments_xtd/email_followup_comment.txt:10
+#: templates/django_comments_xtd/removal_notification_email.txt:3
+#, fuzzy
+#| msgid "Comment reply"
+msgid "Comment"
+msgstr "Réponse à un commentaire"
+
+#: templates/comments/delete.html:5
+msgid "Remove comment"
+msgstr "Supprimer le commentaire"
+
+#: templates/comments/delete.html:9
+msgid "Remove this comment?"
+msgstr "Supprimer le commentaire ?"
+
+#: templates/comments/delete.html:12
+msgid ""
+"As a moderator you can delete comments. Deleting a comment does not remove "
+"it from the site, only prevents your website from showing the text. Click on "
+"the remove button to delete the following comment:"
+msgstr ""
+"En tant que modérateur, vous pouvez supprimer les commentaires. La "
+"suppression d'un commentaire ne l'exclut pas du site, elle empêche juste "
+"votre site d'afficher le texte. Cliquez sur le bouton Supprimer pour "
+"supprimer le commentaire suivant :"
+
+#: templates/comments/delete.html:45
+msgid "Remove"
+msgstr "Supprimer"
+
+#: templates/comments/delete.html:46 templates/comments/flag.html:57
+#: templates/django_comments_xtd/dislike.html:74
+#: templates/django_comments_xtd/like.html:73
+msgid "cancel"
+msgstr "annuler"
+
+#: templates/comments/deleted.html:5
+msgid "Comment removed"
+msgstr "Commentaire supprimé"
+
+#: templates/comments/deleted.html:12
+msgid "The comment has been removed."
+msgstr "Le commentaire a été supprimé."
+
+#: templates/comments/deleted.html:13 templates/comments/flagged.html:13
+msgid ""
+"Thank you for taking the time to improve the quality of discussion in our "
+"site."
+msgstr ""
+"Merci d'avoir pris le temps d'améliorer la qualité de la discussion sur "
+"notre site."
+
+#: templates/comments/flag.html:5
+msgid "Flag comment"
+msgstr "Signaler un commentaire"
+
+#: templates/comments/flag.html:13
+msgid "Flag this comment?"
+msgstr "Signaler ce commentaire ?"
+
+#: templates/comments/flag.html:16
+msgid ""
+"Click on the flag button to mark the following comment as inappropriate."
+msgstr ""
+"Cliquez sur le bouton signaler pour marquer le commentaire suivant comme "
+"inapproprié."
+
+#: templates/comments/flag.html:41
+#: templates/django_comments_xtd/comment.html:11
+#: templates/django_comments_xtd/dislike.html:49
+#: templates/django_comments_xtd/like.html:47
+msgid "Posted to "
+msgstr ""
+
+#: templates/comments/flag.html:56
+msgid "Flag"
+msgstr "Signaler"
+
+#: templates/comments/flagged.html:5
+msgid "Comment flagged"
+msgstr "Commentaire signalé"
+
+#: templates/comments/flagged.html:12
+msgid "The comment has been flagged."
+msgstr "Le commentaire a été signalé."
+
+#: templates/comments/form.html:70
+msgid "send"
+msgstr ""
+
+#: templates/comments/form.html:71
+msgid "preview"
+msgstr ""
+
+#: templates/comments/list.html:25
+#: templates/django_comments_xtd/comment_tree.html:45
+msgid "Reply"
+msgstr "Répondre"
+
+#: templates/comments/posted.html:6
+msgid "Comment confirmation requested."
+msgstr "Confirmation du commentaire demandée."
+
+#: templates/comments/posted.html:12
+#, fuzzy
+#| msgid ""
+#| "A confirmation message has been sent to your\n"
+#| "  email address. Please, click on the link in the message to confirm\n"
+#| "  your comment."
+msgid ""
+"A confirmation message has been sent to your\n"
+"            email address. Please, click on the link in the message to "
+"confirm\n"
+"            your comment."
+msgstr ""
+"Un message de confirmation a été envoyé à votre\n"
+"adresse email. Veuillez cliquer sur le lien dans le message pour confirmer\n"
+"votre commentaire."
+
+#: templates/comments/posted.html:17
+msgid "Go back to"
+msgstr ""
+
+#: templates/comments/preview.html:5 templates/comments/preview.html:10
+msgid "Preview your comment"
+msgstr "Aperçu de votre commentaire"
+
+#: templates/comments/preview.html:14
+#, fuzzy
+#| msgid "Preview your comment for:"
+msgid "Preview of your comment for:"
+msgstr "Aperçu de votre commentaire pour :"
+
+#: templates/comments/preview.html:21
+msgid "Empty comment."
+msgstr "Commentaire vide."
+
+#: templates/comments/preview.html:48
+#: templates/django_comments_xtd/reply.html:32
+#, fuzzy
+#| msgid "Your comment"
+msgid "Post your comment"
+msgstr "Votre commentaire"
+
+#: templates/django_comments_xtd/comment_list.html:11
+msgid "List of comments"
+msgstr "Liste de commentaires"
+
+#: templates/django_comments_xtd/comment_list.html:21
+#, fuzzy
+#| msgid "Your comment"
+msgid "No comments yet."
+msgstr "Votre commentaire"
+
+#: templates/django_comments_xtd/comment_tree.html:12
+msgid "moderator"
+msgstr "modérateur"
+
+#: templates/django_comments_xtd/comment_tree.html:12
+msgid "comment permalink"
+msgstr "lien permanent du commentaire"
+
+#: templates/django_comments_xtd/comment_tree.html:17
+#, python-format
+msgid "A user has flagged this comment as inappropriate."
+msgid_plural "%(counter)s users have flagged this comment as inappropriate."
+msgstr[0] "Un utilisateur a signalé ce commentaire comme inapproprié."
+msgstr[1] ""
+"%(counter)s utilisateurs ont signalé ce commentaire comme inapproprié."
+
+#: templates/django_comments_xtd/comment_tree.html:21
+msgid "comment flagged"
+msgstr "commentaire signalé"
+
+#: templates/django_comments_xtd/comment_tree.html:25
+msgid "flag comment"
+msgstr "signaler le commentaire"
+
+#: templates/django_comments_xtd/comment_tree.html:30
+msgid "remove comment"
+msgstr "supprimer le commentaire"
+
+#: templates/django_comments_xtd/discarded.html:4
+msgid "Comment discarded"
+msgstr "Commentaire rejeté"
+
+#: templates/django_comments_xtd/discarded.html:7
+msgid "Comment automatically discarded"
+msgstr "Commentaire automatiquement rejeté"
+
+#: templates/django_comments_xtd/discarded.html:8
+msgid "Sorry, your comment has been automatically discarded"
+msgstr "Désolé, votre commentaire a été automatiquement rejeté"
+
+#: templates/django_comments_xtd/dislike.html:5
+#: templates/django_comments_xtd/like.html:5
+msgid "Confirm your opinion"
+msgstr "Confirmer votre opinion"
+
+#: templates/django_comments_xtd/dislike.html:15
+msgid "You didn't like this comment, do you want to change it?"
+msgstr "Vous n'avez pas aimé ce commentaire, voulez-vous le changer?"
+
+#: templates/django_comments_xtd/dislike.html:17
+msgid "Do you dislike this comment?"
+msgstr "Vous n'aimez pas ce commentaire ?"
+
+#: templates/django_comments_xtd/dislike.html:22
+#: templates/django_comments_xtd/like.html:22
+msgid "Please, confirm your opinion about the comment."
+msgstr "Veuillez confirmer votre opinion sur le commentaire."
+
+#: templates/django_comments_xtd/dislike.html:62
+msgid ""
+"Click on the \"withdraw\" button if you want to withdraw your negative "
+"opinion on this comment."
+msgstr ""
+"Cliquez sur le bouton « retirer » si vous souhaitez retirer votre avis "
+"négatif sur ce commentaire."
+
+#: templates/django_comments_xtd/dislike.html:70
+#: templates/django_comments_xtd/like.html:69
+msgid "Withdraw"
+msgstr "Retirer"
+
+#: templates/django_comments_xtd/dislike.html:72
+msgid "I dislike it"
+msgstr "Je ne l'aime pas"
+
+#: templates/django_comments_xtd/disliked.html:4
+msgid "You disliked the comment"
+msgstr "Vous n'avez pas aimé ce commentaire"
+
+#: templates/django_comments_xtd/disliked.html:7
+#: templates/django_comments_xtd/liked.html:7
+msgid "Thanks for taking the time to participate."
+msgstr "Merci d'avoir pris le temps de participer."
+
+#: templates/django_comments_xtd/email_confirmation_request.html:3
+#: templates/django_comments_xtd/email_confirmation_request.txt:3
+msgid ""
+"You or someone in behalf of you have requested to post a comment into this "
+"page:"
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:7
+#: templates/django_comments_xtd/email_followup_comment.html:8
+#, fuzzy
+#| msgid "Remove comment"
+msgid "The comment"
+msgstr "Supprimer le commentaire"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:11
+#: templates/django_comments_xtd/email_confirmation_request.txt:11
+#, python-format
+msgid ""
+"If you do not wish to post the comment, please ignore this message or report "
+"an incident to %(contact)s. Otherwise click on the link below to confirm the "
+"comment."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:15
+#: templates/django_comments_xtd/email_confirmation_request.txt:15
+msgid ""
+"If clicking does not work, you can also copy and paste the address into your "
+"browser's address window."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:17
+#: templates/django_comments_xtd/email_confirmation_request.txt:16
+#, fuzzy
+#| msgid "Preview your comment"
+msgid "Thanks for your comment!"
+msgstr "Aperçu de votre commentaire"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:19
+#: templates/django_comments_xtd/email_confirmation_request.txt:19
+#: templates/django_comments_xtd/email_followup_comment.html:14
+#: templates/django_comments_xtd/email_followup_comment.txt:20
+msgid "Kind regards"
+msgstr "Cordialement"
+
+#: templates/django_comments_xtd/email_followup_comment.html:3
+#: templates/django_comments_xtd/email_followup_comment.txt:4
+msgid "There is a new comment following up yours."
+msgstr "Il y a un nouveau commentaire qui suit le vôtre."
+
+#: templates/django_comments_xtd/email_followup_comment.html:12
+#, python-format
+msgid ""
+"Click <a href=\"http://%(site_domain)s%(mute_url)s\">http://%(site_domain)s"
+"%(mute_url_short)s...</a> to mute the comments thread. You will no longer "
+"receive follow-up notifications."
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:6
+msgid "Post"
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:15
+msgid ""
+"Click on the following link to mute the comments thread. You will no longer "
+"receive follow-up notifications:"
+msgstr ""
+
+#: templates/django_comments_xtd/like.html:15
+msgid "You liked this comment, do you want to change it?"
+msgstr "Vous avez aimé ce commentaire, voulez-vous le changer ?"
+
+#: templates/django_comments_xtd/like.html:17
+msgid "Do you like this comment?"
+msgstr "Aimez-vous ce commentaire ?"
+
+#: templates/django_comments_xtd/like.html:60
+msgid ""
+"Click on the \"withdraw\" button if you want to withdraw your positive "
+"opinion on this comment."
+msgstr ""
+"Cliquez sur le bouton \"retirer\" si vous souhaitez retirer votre opinion "
+"positive sur ce commentaire."
+
+#: templates/django_comments_xtd/like.html:71
+msgid "I like it"
+msgstr "J'aime"
+
+#: templates/django_comments_xtd/liked.html:4
+msgid "Your opinion is appreciated"
+msgstr "Votre avis est apprécié"
+
+#: templates/django_comments_xtd/moderated.html:4
+msgid "Comment requires approval"
+msgstr "Le commentaire nécessite une approbation"
+
+#: templates/django_comments_xtd/moderated.html:8
+msgid "Comment in moderation"
+msgstr "Commentaire en modération"
+
+#: templates/django_comments_xtd/moderated.html:14
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "  Your comment is in moderation.<br/>\n"
+#| "  It has to be reviewed before being published.<br/>\n"
+#| "  Thank you for your patience and understanding.\n"
+#| "  "
+msgid ""
+"\n"
+"            Your comment is in moderation.<br/>\n"
+"            It has to be reviewed before being published.<br/>\n"
+"            Thank you for your patience and understanding.\n"
+"            "
+msgstr ""
+"\n"
+"Votre commentaire est en modération. <br/>\n"
+"Il doit être revu avant d'être publié. <br/>\n"
+"Merci pour votre patience et votre compréhension."
+
+#: templates/django_comments_xtd/moderated.html:22
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "  Go back to <a href=\"%(content_object_url)s\">%(content_object_str)s</"
+#| "a>\n"
+#| "  "
+msgid ""
+"\n"
+"            Go back to: <a href=\"%(content_object_url)s\">"
+"%(content_object_str)s</a>\n"
+"            "
+msgstr ""
+"\n"
+"Revenir à <a href=\"%(content_object_url)s\">%(content_object_str)s</a>"
+
+#: templates/django_comments_xtd/muted.html:4
+msgid "Comment thread muted"
+msgstr "Notifications du fil de commentaire enlevée"
+
+#: templates/django_comments_xtd/muted.html:7
+msgid "Comment thread has been muted"
+msgstr "Les notifications du fil de commentaires ont été coupées"
+
+#: templates/django_comments_xtd/muted.html:9
+msgid "You will no longer receive email notifications for comments sent to"
+msgstr ""
+"Vous ne recevrez plus de notifications par email pour les commentaires "
+"envoyés à"
+
+#: templates/django_comments_xtd/only_users_can_post.html:5
+msgid "Only registered users can post comments."
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:1
+msgid "A removal suggestion has been received for the following comment:"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:7
+msgid "Posted to the following URL"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:10
+msgid "Removal suggested by"
+msgstr ""
+
+#: templates/django_comments_xtd/reply.html:6
+msgid "Comment reply"
+msgstr "Réponse à un commentaire"
+
+#: templates/django_comments_xtd/reply.html:11
+msgid "Reply to comment"
+msgstr "Répondre à un commentaire"
+
+#: tests/apiauth.py:17
+msgid "Invalid token header. No credentials provided."
+msgstr ""
+
+#: tests/apiauth.py:20
+msgid "Invalid token header.Token string should not contain spaces."
+msgstr ""
+
+#: tests/apiauth.py:27
+msgid ""
+"Invalid token header. Token string should not contain invalid characters."
+msgstr ""
+
+#: views.py:60
 msgid "comment confirmation request"
 msgstr "Confirmation du commentaire envoyé"
 
-#: views.py:209
+#: views.py:278
 msgid "new comment posted"
 msgstr "nouveau commentaire envoyé"
 
-#~ msgid "Remove comment"
-#~ msgstr "Supprimer le commentaire"
-
-#~ msgid "Remove this comment?"
-#~ msgstr "Supprimer le commentaire ?"
-
-#~ msgid ""
-#~ "As a moderator you can delete comments. Deleting a comment does not remove "
-#~ "it from the site, only prevents your website from showing the text. Click on"
-#~ " the remove button to delete the following comment:"
-#~ msgstr ""
-#~ "En tant que modérateur, vous pouvez supprimer les commentaires. La "
-#~ "suppression d'un commentaire ne l'exclut pas du site, elle empêche juste "
-#~ "votre site d'afficher le texte. Cliquez sur le bouton Supprimer pour "
-#~ "supprimer le commentaire suivant :"
-
-#~ msgid "Remove"
-#~ msgstr "Supprimer"
-
-#~ msgid "Comment removed"
-#~ msgstr "Commentaire supprimé"
-
-#~ msgid "The comment has been removed."
-#~ msgstr "Le commentaire a été supprimé."
-
-#~ msgid ""
-#~ "Thank you for taking the time to improve the quality of discussion in our "
-#~ "site."
-#~ msgstr ""
-#~ "Merci d'avoir pris le temps d'améliorer la qualité de la discussion sur "
-#~ "notre site."
-
-#~ msgid "Flag comment"
-#~ msgstr "Signaler un commentaire"
-
-#~ msgid "Flag this comment?"
-#~ msgstr "Signaler ce commentaire ?"
-
-#~ msgid ""
-#~ "Click on the flag button to mark the following comment as inappropriate."
-#~ msgstr ""
-#~ "Cliquez sur le bouton signaler pour marquer le commentaire suivant comme "
-#~ "inapproprié."
-
-#~ msgid "Flag"
-#~ msgstr "Signaler"
-
-#~ msgid "cancel"
-#~ msgstr "annuler"
-
-#~ msgid "Comment flagged"
-#~ msgstr "Commentaire signalé"
-
-#~ msgid "The comment has been flagged."
-#~ msgstr "Le commentaire a été signalé."
-
-#~ msgid "Reply"
-#~ msgstr "Répondre"
-
-#~ msgid "Comment confirmation requested."
-#~ msgstr "Confirmation du commentaire demandée."
-
-#~ msgid ""
-#~ "A confirmation message has been sent to your\n"
-#~ "  email address. Please, click on the link in the message to confirm\n"
-#~ "  your comment."
-#~ msgstr ""
-#~ "Un message de confirmation a été envoyé à votre\n"
-#~ "adresse email. Veuillez cliquer sur le lien dans le message pour confirmer\n"
-#~ "votre commentaire."
-
-#~ msgid "Preview your comment"
-#~ msgstr "Aperçu de votre commentaire"
-
-#~ msgid "Preview your comment for:"
-#~ msgstr "Aperçu de votre commentaire pour :"
-
-#~ msgid "Empty comment."
-#~ msgstr "Commentaire vide."
-
-#~ msgid "List of comments"
-#~ msgstr "Liste de commentaires"
-
-#~ msgid "moderator"
-#~ msgstr "modérateur"
-
-#~ msgid "comment permalink"
-#~ msgstr "lien permanent du commentaire"
-
-#~ msgid "comment flagged"
-#~ msgstr "commentaire signalé"
-
-#~ msgid "flag comment"
-#~ msgstr "signaler le commentaire"
-
-#~ msgid "remove comment"
-#~ msgstr "supprimer le commentaire"
-
-#~ msgid "A user has flagged this comment as inappropriate."
-#~ msgid_plural "%(counter)s users have flagged this comment as inappropriate."
-#~ msgstr[0] "Un utilisateur a signalé ce commentaire comme inapproprié."
-#~ msgstr[1] ""
-#~ "%(counter)s utilisateurs ont signalé ce commentaire comme inapproprié."
-
-#~ msgid "Comment discarded"
-#~ msgstr "Commentaire rejeté"
-
-#~ msgid "Comment automatically discarded"
-#~ msgstr "Commentaire automatiquement rejeté"
-
-#~ msgid "Sorry, your comment has been automatically discarded"
-#~ msgstr "Désolé, votre commentaire a été automatiquement rejeté"
-
-#~ msgid "Confirm your opinion"
-#~ msgstr "Confirmer votre opinion"
-
-#~ msgid "You didn't like this comment, do you want to change it?"
-#~ msgstr "Vous n'avez pas aimé ce commentaire, voulez-vous le changer?"
-
-#~ msgid "Do you dislike this comment?"
-#~ msgstr "Vous n'aimez pas ce commentaire ?"
-
-#~ msgid "Please, confirm your opinion about the comment."
-#~ msgstr "Veuillez confirmer votre opinion sur le commentaire."
-
-#~ msgid ""
-#~ "Click on the \"withdraw\" button if you want to withdraw your negative "
-#~ "opinion on this comment."
-#~ msgstr ""
-#~ "Cliquez sur le bouton « retirer » si vous souhaitez retirer votre avis "
-#~ "négatif sur ce commentaire."
-
-#~ msgid "Withdraw"
-#~ msgstr "Retirer"
-
-#~ msgid "I dislike it"
-#~ msgstr "Je ne l'aime pas"
-
-#~ msgid "You disliked the comment"
-#~ msgstr "Vous n'avez pas aimé ce commentaire"
-
-#~ msgid "Thanks for taking the time to participate."
-#~ msgstr "Merci d'avoir pris le temps de participer."
-
-#~ msgid "There is a new comment following up yours."
-#~ msgstr "Il y a un nouveau commentaire qui suit le vôtre."
-
-#~ msgid "Kind regards"
+#, fuzzy
+#~| msgid "Kind regards"
+#~ msgid "Kind regards,"
 #~ msgstr "Cordialement"
-
-#~ msgid "You liked this comment, do you want to change it?"
-#~ msgstr "Vous avez aimé ce commentaire, voulez-vous le changer ?"
-
-#~ msgid "Do you like this comment?"
-#~ msgstr "Aimez-vous ce commentaire ?"
-
-#~ msgid ""
-#~ "Click on the \"withdraw\" button if you want to withdraw your positive "
-#~ "opinion on this comment."
-#~ msgstr ""
-#~ "Cliquez sur le bouton \"retirer\" si vous souhaitez retirer votre opinion "
-#~ "positive sur ce commentaire."
-
-#~ msgid "I like it"
-#~ msgstr "J'aime"
-
-#~ msgid "Your opinion is appreciated"
-#~ msgstr "Votre avis est apprécié"
-
-#~ msgid "Comment requires approval"
-#~ msgstr "Le commentaire nécessite une approbation"
-
-#~ msgid "Comment in moderation"
-#~ msgstr "Commentaire en modération"
-
-#~ msgid ""
-#~ "\n"
-#~ "  Your comment is in moderation.<br/>\n"
-#~ "  It has to be reviewed before being published.<br/>\n"
-#~ "  Thank you for your patience and understanding.\n"
-#~ "  "
-#~ msgstr ""
-#~ "\n"
-#~ "Votre commentaire est en modération. <br/>\n"
-#~ "Il doit être revu avant d'être publié. <br/>\n"
-#~ "Merci pour votre patience et votre compréhension."
-
-#~ msgid ""
-#~ "\n"
-#~ "  Go back to <a href=\"%(content_object_url)s\">%(content_object_str)s</a>\n"
-#~ "  "
-#~ msgstr ""
-#~ "\n"
-#~ "Revenir à <a href=\"%(content_object_url)s\">%(content_object_str)s</a>"
-
-#~ msgid "Comment thread muted"
-#~ msgstr "Notifications du fil de commentaire enlevée"
-
-#~ msgid "Comment thread has been muted"
-#~ msgstr "Les notifications du fil de commentaires ont été coupées"
-
-#~ msgid "You will no longer receive email notifications for comments sent to"
-#~ msgstr ""
-#~ "Vous ne recevrez plus de notifications par email pour les commentaires "
-#~ "envoyés à"
-
-#~ msgid "Comment reply"
-#~ msgstr "Réponse à un commentaire"
-
-#~ msgid "Reply to comment"
-#~ msgstr "Répondre à un commentaire"

--- a/django_comments_xtd/locale/it/LC_MESSAGES/django.po
+++ b/django_comments_xtd/locale/it/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2.8.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-12 15:47+0100\n"
+"POT-Creation-Date: 2022-09-17 23:38+0200\n"
 "PO-Revision-Date: 2021-02-13 16:01+0053\n"
 "Last-Translator: DLRSP <dlrsp-dev@gmail.com>\n"
 "Language-Team: DLRSP <dlrsp-dev@gmail.com>\n"
@@ -18,84 +18,118 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.9.3\n"
 
-#: .\api\serializers.my.py:193 .\api\serializers.py:277
-#: .\templates\comments\list.html:17
-#: .\templates\django_comments_xtd\comment.html:15
-#: .\templates\django_comments_xtd\comment_tree.html:38
+#: api/serializers.py:277 templates/comments/list.html:17
+#: templates/django_comments_xtd/comment.html:15
+#: templates/django_comments_xtd/comment_tree.html:36
 msgid "This comment has been removed."
 msgstr "Questo commento è stato rimosso."
 
-#: .\forms.py:13
+#: forms.py:13
 msgid "Notify me about follow-up comments"
 msgstr "Notificami riguardo i successivi commenti"
 
-#: .\forms.py:28
+#: forms.py:29
 msgid "Name"
 msgstr "Nome"
 
-#: .\forms.py:29
+#: forms.py:31
 msgid "name"
 msgstr "nome"
 
-#: .\forms.py:32
+#: forms.py:33
 msgid "Mail"
 msgstr "Mail"
 
-#: .\forms.py:32
+#: forms.py:34
 msgid "Required for comment verification"
 msgstr "Necessario per verificare il commento."
 
-#: .\forms.py:33
+#: forms.py:36
 msgid "mail address"
 msgstr "indirizzo mail"
 
-#: .\forms.py:36
+#: forms.py:38
 msgid "Link"
 msgstr "Link"
 
-#: .\forms.py:38
+#: forms.py:41
 msgid "url your name links to (optional)"
 msgstr "url collegato al tuo nome (facoltativo)"
 
-#: .\forms.py:41
+#: forms.py:45
 msgid "Your comment"
 msgstr "Tuo commento"
 
-#: .\models.py:68
+#: models.py:68
 msgid "Notify follow-up comments"
 msgstr "Notifica i successivi commenti"
 
-#: .\templates\comments\delete.html:5
+#: templates/404.html:9
+msgid "Page not found"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:1
+msgid "A new comment has been sent to the following URL:"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:5
+#: templates/django_comments_xtd/email_followup_comment.html:5
+#: templates/django_comments_xtd/email_followup_comment.txt:8
+msgid "Sent by"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:6
+#, fuzzy
+#| msgid "mail address"
+msgid "Email address"
+msgstr "indirizzo mail"
+
+#: templates/comments/comment_notification_email.txt:8
+#: templates/django_comments_xtd/email_confirmation_request.txt:7
+#: templates/django_comments_xtd/email_followup_comment.txt:10
+#: templates/django_comments_xtd/removal_notification_email.txt:3
+#, fuzzy
+#| msgid "Comment reply"
+msgid "Comment"
+msgstr "Risposta al commento"
+
+#: templates/comments/delete.html:5
 msgid "Remove comment"
 msgstr "Rimuovi commento"
 
-#: .\templates\comments\delete.html:9
+#: templates/comments/delete.html:9
 msgid "Remove this comment?"
 msgstr "Rimuovere questo commento?"
 
-#: .\templates\comments\delete.html:12
+#: templates/comments/delete.html:12
 msgid ""
 "As a moderator you can delete comments. Deleting a comment does not remove "
-"it from the site, only prevents your website from showing the text. Click on"
-" the remove button to delete the following comment:"
+"it from the site, only prevents your website from showing the text. Click on "
+"the remove button to delete the following comment:"
 msgstr ""
 "Come moderatore puoi cancellare i commenti. Cancellare un commento non lo "
-"rimuove dal sito, solo evita che questo sia mostrato. Clicca sul pulsante di"
-" rimozione per cancellare il seguente commento:  "
+"rimuove dal sito, solo evita che questo sia mostrato. Clicca sul pulsante di "
+"rimozione per cancellare il seguente commento:  "
 
-#: .\templates\comments\delete.html:45
+#: templates/comments/delete.html:45
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: .\templates\comments\deleted.html:5
+#: templates/comments/delete.html:46 templates/comments/flag.html:57
+#: templates/django_comments_xtd/dislike.html:74
+#: templates/django_comments_xtd/like.html:73
+msgid "cancel"
+msgstr "cancella"
+
+#: templates/comments/deleted.html:5
 msgid "Comment removed"
 msgstr "Commento rimosso"
 
-#: .\templates\comments\deleted.html:12
+#: templates/comments/deleted.html:12
 msgid "The comment has been removed."
 msgstr "Il commento è stato rimosso."
 
-#: .\templates\comments\deleted.html:13 .\templates\comments\flagged.html:13
+#: templates/comments/deleted.html:13 templates/comments/flagged.html:13
 msgid ""
 "Thank you for taking the time to improve the quality of discussion in our "
 "site."
@@ -103,108 +137,106 @@ msgstr ""
 "Grazie per il tempo dedicato a migliorare la qualità della discussione nel "
 "nostro sito."
 
-#: .\templates\comments\flag.html:5
+#: templates/comments/flag.html:5
 msgid "Flag comment"
 msgstr "Marca come inadeguato"
 
-#: .\templates\comments\flag.html:13
+#: templates/comments/flag.html:13
 msgid "Flag this comment?"
 msgstr "Marca questo commento come inadeguato?"
 
-#: .\templates\comments\flag.html:16
+#: templates/comments/flag.html:16
 msgid ""
 "Click on the flag button to mark the following comment as inappropriate."
 msgstr ""
-"Clicca sul bottone Marca per marcare il seguente commento come "
-"inappropriato."
+"Clicca sul bottone Marca per marcare il seguente commento come inappropriato."
 
-#: .\templates\comments\flag.html:41
-#: .\templates\django_comments_xtd\comment.html:11
-#: .\templates\django_comments_xtd\dislike.html:49
-#: .\templates\django_comments_xtd\like.html:47
+#: templates/comments/flag.html:41
+#: templates/django_comments_xtd/comment.html:11
+#: templates/django_comments_xtd/dislike.html:49
+#: templates/django_comments_xtd/like.html:47
 msgid "Posted to "
 msgstr "Inviato a "
 
-#: .\templates\comments\flag.html:56
+#: templates/comments/flag.html:56
 msgid "Flag"
 msgstr "Marca"
 
-#: .\templates\comments\flag.html:57
-#: .\templates\django_comments_xtd\dislike.html:74
-#: .\templates\django_comments_xtd\like.html:73
-msgid "cancel"
-msgstr "cancella"
-
-#: .\templates\comments\flagged.html:5
+#: templates/comments/flagged.html:5
 msgid "Comment flagged"
 msgstr "Commento marcato"
 
-#: .\templates\comments\flagged.html:12
+#: templates/comments/flagged.html:12
 msgid "The comment has been flagged."
 msgstr "Il commento è stato marcato come inappropriato."
 
-#: .\templates\comments\form.html:70
+#: templates/comments/form.html:70
 msgid "send"
 msgstr "invia"
 
-#: .\templates\comments\form.html:71
+#: templates/comments/form.html:71
 msgid "preview"
 msgstr "anteprima"
 
-#: .\templates\comments\list.html:25
-#: .\templates\django_comments_xtd\comment_tree.html:47
+#: templates/comments/list.html:25
+#: templates/django_comments_xtd/comment_tree.html:45
 msgid "Reply"
 msgstr "Rispondi"
 
-#: .\templates\comments\posted.html:6
+#: templates/comments/posted.html:6
 msgid "Comment confirmation requested."
 msgstr "Conferma di commento inviata. "
 
-#: .\templates\comments\posted.html:12
-#| msgid ""
-#| "A confirmation message has been sent to your\n"
-#| "  email address. Please, click on the link in the message to confirm\n"
-#| "  your comment."
+#: templates/comments/posted.html:12
 msgid ""
 "A confirmation message has been sent to your\n"
-"            email address. Please, click on the link in the message to confirm\n"
+"            email address. Please, click on the link in the message to "
+"confirm\n"
 "            your comment."
 msgstr ""
 "Un messaggio di conferma è stato inviato al tuo indirizzo mail.\n"
 "Perfavore, cliccka sul link nel messaggio per confermare il tuo commento."
 
-#: .\templates\comments\preview.html:5 .\templates\comments\preview.html:10
+#: templates/comments/posted.html:17
+msgid "Go back to"
+msgstr ""
+
+#: templates/comments/preview.html:5 templates/comments/preview.html:10
 msgid "Preview your comment"
 msgstr "Il tuo commento in anteprima"
 
-#: .\templates\comments\preview.html:14
-#| msgid "Preview your comment for:"
+#: templates/comments/preview.html:14
 msgid "Preview of your comment for:"
 msgstr "Il tuo commento in anteprima per:"
 
-#: .\templates\comments\preview.html:21
+#: templates/comments/preview.html:21
 msgid "Empty comment."
 msgstr "Commento vuoto."
 
-#: .\templates\comments\preview.html:48
-#: .\templates\django_comments_xtd\reply.html:32
-#| msgid "Your comment"
+#: templates/comments/preview.html:48
+#: templates/django_comments_xtd/reply.html:32
 msgid "Post your comment"
 msgstr "Invia il tuo commento"
 
-#: .\templates\django_comments_xtd\comment_list.html:11
+#: templates/django_comments_xtd/comment_list.html:11
 msgid "List of comments"
 msgstr "Lista dei commenti"
 
-#: .\templates\django_comments_xtd\comment_tree.html:14
+#: templates/django_comments_xtd/comment_list.html:21
+#, fuzzy
+#| msgid "Your comment"
+msgid "No comments yet."
+msgstr "Tuo commento"
+
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "moderator"
 msgstr "moderatore"
 
-#: .\templates\django_comments_xtd\comment_tree.html:14
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "comment permalink"
 msgstr "link del commento"
 
-#: .\templates\django_comments_xtd\comment_tree.html:19
+#: templates/django_comments_xtd/comment_tree.html:17
 #, python-format
 msgid "A user has flagged this comment as inappropriate."
 msgid_plural "%(counter)s users have flagged this comment as inappropriate."
@@ -212,49 +244,49 @@ msgstr[0] "Un utente ha segnato questo commento come inappropriato."
 msgstr[1] ""
 "%(counter)s utenti hanno segnato questo commento come inappropriato."
 
-#: .\templates\django_comments_xtd\comment_tree.html:23
+#: templates/django_comments_xtd/comment_tree.html:21
 msgid "comment flagged"
 msgstr "commento inadeguato"
 
-#: .\templates\django_comments_xtd\comment_tree.html:27
+#: templates/django_comments_xtd/comment_tree.html:25
 msgid "flag comment"
 msgstr "marca inadeguato"
 
-#: .\templates\django_comments_xtd\comment_tree.html:32
+#: templates/django_comments_xtd/comment_tree.html:30
 msgid "remove comment"
 msgstr "rimuovi commento"
 
-#: .\templates\django_comments_xtd\discarded.html:4
+#: templates/django_comments_xtd/discarded.html:4
 msgid "Comment discarded"
 msgstr "Commento scartato"
 
-#: .\templates\django_comments_xtd\discarded.html:7
+#: templates/django_comments_xtd/discarded.html:7
 msgid "Comment automatically discarded"
 msgstr "Commento automaticamente scartato"
 
-#: .\templates\django_comments_xtd\discarded.html:8
+#: templates/django_comments_xtd/discarded.html:8
 msgid "Sorry, your comment has been automatically discarded"
 msgstr "Ci dispiace, il tuo commento è stato automaticamente scartato"
 
-#: .\templates\django_comments_xtd\dislike.html:5
-#: .\templates\django_comments_xtd\like.html:5
+#: templates/django_comments_xtd/dislike.html:5
+#: templates/django_comments_xtd/like.html:5
 msgid "Confirm your opinion"
 msgstr "Conferma la tua opinione"
 
-#: .\templates\django_comments_xtd\dislike.html:15
+#: templates/django_comments_xtd/dislike.html:15
 msgid "You didn't like this comment, do you want to change it?"
 msgstr "Non ti è piaciuto questo commento, vuoi cambiare la tua opinione?"
 
-#: .\templates\django_comments_xtd\dislike.html:17
+#: templates/django_comments_xtd/dislike.html:17
 msgid "Do you dislike this comment?"
 msgstr "Non ti piace questo commento?"
 
-#: .\templates\django_comments_xtd\dislike.html:22
-#: .\templates\django_comments_xtd\like.html:22
+#: templates/django_comments_xtd/dislike.html:22
+#: templates/django_comments_xtd/like.html:22
 msgid "Please, confirm your opinion about the comment."
 msgstr "Perfavore, conferma la tua opinione sul commento."
 
-#: .\templates\django_comments_xtd\dislike.html:62
+#: templates/django_comments_xtd/dislike.html:62
 msgid ""
 "Click on the \"withdraw\" button if you want to withdraw your negative "
 "opinion on this comment."
@@ -262,41 +294,100 @@ msgstr ""
 "Clicca sul bottone \"ritira\" se vuoi ritirare la tua opinione negativa su "
 "questo commento."
 
-#: .\templates\django_comments_xtd\dislike.html:70
-#: .\templates\django_comments_xtd\like.html:69
+#: templates/django_comments_xtd/dislike.html:70
+#: templates/django_comments_xtd/like.html:69
 msgid "Withdraw"
 msgstr "Ritira"
 
-#: .\templates\django_comments_xtd\dislike.html:72
+#: templates/django_comments_xtd/dislike.html:72
 msgid "I dislike it"
 msgstr "Non mi piace"
 
-#: .\templates\django_comments_xtd\disliked.html:4
+#: templates/django_comments_xtd/disliked.html:4
 msgid "You disliked the comment"
 msgstr "Non ti piace il commento"
 
-#: .\templates\django_comments_xtd\disliked.html:7
-#: .\templates\django_comments_xtd\liked.html:7
+#: templates/django_comments_xtd/disliked.html:7
+#: templates/django_comments_xtd/liked.html:7
 msgid "Thanks for taking the time to participate."
 msgstr "Grazie per il tempo dedicato a partecipare."
 
-#: .\templates\django_comments_xtd\email_followup_comment.txt:4
-msgid "There is a new comment following up yours."
-msgstr "C'è un nuovo commento in seguito al tuo."
+#: templates/django_comments_xtd/email_confirmation_request.html:3
+#: templates/django_comments_xtd/email_confirmation_request.txt:3
+msgid ""
+"You or someone in behalf of you have requested to post a comment into this "
+"page:"
+msgstr ""
 
-#: .\templates\django_comments_xtd\email_followup_comment.txt:20
+#: templates/django_comments_xtd/email_confirmation_request.html:7
+#: templates/django_comments_xtd/email_followup_comment.html:8
+#, fuzzy
+#| msgid "Remove comment"
+msgid "The comment"
+msgstr "Rimuovi commento"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:11
+#: templates/django_comments_xtd/email_confirmation_request.txt:11
+#, python-format
+msgid ""
+"If you do not wish to post the comment, please ignore this message or report "
+"an incident to %(contact)s. Otherwise click on the link below to confirm the "
+"comment."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:15
+#: templates/django_comments_xtd/email_confirmation_request.txt:15
+msgid ""
+"If clicking does not work, you can also copy and paste the address into your "
+"browser's address window."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:17
+#: templates/django_comments_xtd/email_confirmation_request.txt:16
+#, fuzzy
+#| msgid "Post your comment"
+msgid "Thanks for your comment!"
+msgstr "Invia il tuo commento"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:19
+#: templates/django_comments_xtd/email_confirmation_request.txt:19
+#: templates/django_comments_xtd/email_followup_comment.html:14
+#: templates/django_comments_xtd/email_followup_comment.txt:20
 msgid "Kind regards"
 msgstr "Cordiali saluti"
 
-#: .\templates\django_comments_xtd\like.html:15
+#: templates/django_comments_xtd/email_followup_comment.html:3
+#: templates/django_comments_xtd/email_followup_comment.txt:4
+msgid "There is a new comment following up yours."
+msgstr "C'è un nuovo commento in seguito al tuo."
+
+#: templates/django_comments_xtd/email_followup_comment.html:12
+#, python-format
+msgid ""
+"Click <a href=\"http://%(site_domain)s%(mute_url)s\">http://%(site_domain)s"
+"%(mute_url_short)s...</a> to mute the comments thread. You will no longer "
+"receive follow-up notifications."
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:6
+msgid "Post"
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:15
+msgid ""
+"Click on the following link to mute the comments thread. You will no longer "
+"receive follow-up notifications:"
+msgstr ""
+
+#: templates/django_comments_xtd/like.html:15
 msgid "You liked this comment, do you want to change it?"
 msgstr "Ti piace questo commento, vuoi cambiare la tua opinione?"
 
-#: .\templates\django_comments_xtd\like.html:17
+#: templates/django_comments_xtd/like.html:17
 msgid "Do you like this comment?"
 msgstr "Ti piace questo commento?"
 
-#: .\templates\django_comments_xtd\like.html:60
+#: templates/django_comments_xtd/like.html:60
 msgid ""
 "Click on the \"withdraw\" button if you want to withdraw your positive "
 "opinion on this comment."
@@ -304,29 +395,23 @@ msgstr ""
 "Clicca sul bottone \"ritira\" se vuoi ritirare la tua opinione positiva su "
 "questo commento."
 
-#: .\templates\django_comments_xtd\like.html:71
+#: templates/django_comments_xtd/like.html:71
 msgid "I like it"
 msgstr "Mi piace"
 
-#: .\templates\django_comments_xtd\liked.html:4
+#: templates/django_comments_xtd/liked.html:4
 msgid "Your opinion is appreciated"
 msgstr "Grazie per la tua opinione"
 
-#: .\templates\django_comments_xtd\moderated.html:4
+#: templates/django_comments_xtd/moderated.html:4
 msgid "Comment requires approval"
 msgstr "Il commento necessita approvazione"
 
-#: .\templates\django_comments_xtd\moderated.html:8
+#: templates/django_comments_xtd/moderated.html:8
 msgid "Comment in moderation"
 msgstr "Commento in moderazione"
 
-#: .\templates\django_comments_xtd\moderated.html:14
-#| msgid ""
-#| "\n"
-#| "  Your comment is in moderation.<br/>\n"
-#| "  It has to be reviewed before being published.<br/>\n"
-#| "  Thank you for your patience and understanding.\n"
-#| "  "
+#: templates/django_comments_xtd/moderated.html:14
 msgid ""
 "\n"
 "            Your comment is in moderation.<br/>\n"
@@ -339,62 +424,81 @@ msgstr ""
 "  Ha necessità di essere revisionato prima della pubblicazione.<br/>\n"
 "  Grazie per la tua pazienza e comprensione."
 
-#: .\templates\django_comments_xtd\moderated.html:22
+#: templates/django_comments_xtd/moderated.html:22
 #, python-format
-#| msgid ""
-#| "\n"
-#| "  Go back to <a href=\"%(content_object_url)s\">%(content_object_str)s</a>\n"
-#| "  "
 msgid ""
 "\n"
-"            Go back to: <a href=\"%(content_object_url)s\">%(content_object_str)s</a>\n"
+"            Go back to: <a href=\"%(content_object_url)s\">"
+"%(content_object_str)s</a>\n"
 "            "
 msgstr ""
 "\n"
-"  Torna indietro a <a href=\"%(content_object_url)s\">%(content_object_str)s</a>\n"
+"  Torna indietro a <a href=\"%(content_object_url)s\">"
+"%(content_object_str)s</a>\n"
 "  "
 
-#: .\templates\django_comments_xtd\muted.html:4
+#: templates/django_comments_xtd/muted.html:4
 msgid "Comment thread muted"
 msgstr "Muta lo scambio di commenti"
 
-#: .\templates\django_comments_xtd\muted.html:7
+#: templates/django_comments_xtd/muted.html:7
 msgid "Comment thread has been muted"
 msgstr "Lo scambio di commenti è stato mutato"
 
-#: .\templates\django_comments_xtd\muted.html:9
+#: templates/django_comments_xtd/muted.html:9
 msgid "You will no longer receive email notifications for comments sent to"
 msgstr "Non riceverai più notifiche mail per i commenti inviati a"
 
-#: .\templates\django_comments_xtd\reply.html:6
+#: templates/django_comments_xtd/only_users_can_post.html:5
+msgid "Only registered users can post comments."
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:1
+msgid "A removal suggestion has been received for the following comment:"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:7
+msgid "Posted to the following URL"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:10
+msgid "Removal suggested by"
+msgstr ""
+
+#: templates/django_comments_xtd/reply.html:6
 msgid "Comment reply"
 msgstr "Risposta al commento"
 
-#: .\templates\django_comments_xtd\reply.html:11
+#: templates/django_comments_xtd/reply.html:11
 msgid "Reply to comment"
 msgstr "Rispondi al commento"
 
-#: .\tests\apiauth.py:17
+#: tests/apiauth.py:17
 msgid "Invalid token header. No credentials provided."
 msgstr "Header del Token invalido. Nessuna credenziale proposta."
 
-#: .\tests\apiauth.py:20
+#: tests/apiauth.py:20
 msgid "Invalid token header.Token string should not contain spaces."
 msgstr "Header del Token invalido. Il Token non deve contenere spazi."
 
-#: .\tests\apiauth.py:27
+#: tests/apiauth.py:27
 msgid ""
 "Invalid token header. Token string should not contain invalid characters."
 msgstr ""
 "Header del Token invalido. Il Token non deve contenere caratteri speciali."
 
-#: .\views.py:59
+#: views.py:60
 msgid "comment confirmation request"
 msgstr "conferma il commento"
 
-#: .\views.py:259
+#: views.py:278
 msgid "new comment posted"
 msgstr "nuovo commento inviato"
+
+#, fuzzy
+#~| msgid "Kind regards"
+#~ msgid "Kind regards,"
+#~ msgstr "Cordiali saluti"
 
 #~ msgid "Thank you, the comment has been removed."
 #~ msgstr "Grazie, il commento è stato rimosso."

--- a/django_comments_xtd/locale/nl/LC_MESSAGES/django.po
+++ b/django_comments_xtd/locale/nl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2.6.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-30 13:39+0200\n"
+"POT-Creation-Date: 2022-09-17 23:38+0200\n"
 "PO-Revision-Date: 2020-05-30 14:40+0200\n"
 "Last-Translator: Jean-Paul Ladage <j.ladage@zestsoftware.nl>\n"
 "Language-Team: Jean-Paul Ladage <j.ladage@zestsoftware.nl>\n"
@@ -17,9 +17,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: api/serializers.py:242 templates/comments/list.html:17
+#: api/serializers.py:277 templates/comments/list.html:17
 #: templates/django_comments_xtd/comment.html:15
-#: templates/django_comments_xtd/comment_tree.html:34
+#: templates/django_comments_xtd/comment_tree.html:36
 msgid "This comment has been removed."
 msgstr "Deze reactie is verwijderd."
 
@@ -27,41 +27,70 @@ msgstr "Deze reactie is verwijderd."
 msgid "Notify me about follow-up comments"
 msgstr "Stuur mij een notificatie als iemand op mijn reactie antwoord."
 
-#: forms.py:28
+#: forms.py:29
 msgid "Name"
 msgstr "Naam"
 
-#: forms.py:29
+#: forms.py:31
 msgid "name"
 msgstr "naam"
 
-#: forms.py:32
+#: forms.py:33
 msgid "Mail"
 msgstr "Mail"
 
-#: forms.py:32
+#: forms.py:34
 msgid "Required for comment verification"
 msgstr "Verplicht voor verificatie per e-mail."
 
-#: forms.py:33
+#: forms.py:36
 msgid "mail address"
 msgstr "e-mailadres"
 
-#: forms.py:36
+#: forms.py:38
 msgid "Link"
 msgstr "Link"
 
-#: forms.py:38
+#: forms.py:41
 msgid "url your name links to (optional)"
 msgstr "URL waar uw naam naar linkt (optioneel)."
 
-#: forms.py:41
+#: forms.py:45
 msgid "Your comment"
 msgstr "Uw reactie"
 
-#: models.py:70
+#: models.py:68
 msgid "Notify follow-up comments"
 msgstr "Notificaties bij reacties."
+
+#: templates/404.html:9
+msgid "Page not found"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:1
+msgid "A new comment has been sent to the following URL:"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:5
+#: templates/django_comments_xtd/email_followup_comment.html:5
+#: templates/django_comments_xtd/email_followup_comment.txt:8
+msgid "Sent by"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:6
+#, fuzzy
+#| msgid "mail address"
+msgid "Email address"
+msgstr "e-mailadres"
+
+#: templates/comments/comment_notification_email.txt:8
+#: templates/django_comments_xtd/email_confirmation_request.txt:7
+#: templates/django_comments_xtd/email_followup_comment.txt:10
+#: templates/django_comments_xtd/removal_notification_email.txt:3
+#, fuzzy
+#| msgid "Comment reply"
+msgid "Comment"
+msgstr "Beantwoorden"
 
 #: templates/comments/delete.html:5
 msgid "Remove comment"
@@ -76,11 +105,19 @@ msgid ""
 "As a moderator you can delete comments. Deleting a comment does not remove "
 "it from the site, only prevents your website from showing the text. Click on "
 "the remove button to delete the following comment:"
-msgstr "As beheerder kunt u reacties verwijderen. Deze worden niet echt verwijderd van de website, alleen verborgen."
+msgstr ""
+"As beheerder kunt u reacties verwijderen. Deze worden niet echt verwijderd "
+"van de website, alleen verborgen."
 
-#: templates/comments/delete.html:41
+#: templates/comments/delete.html:45
 msgid "Remove"
 msgstr "Verwijder"
+
+#: templates/comments/delete.html:46 templates/comments/flag.html:57
+#: templates/django_comments_xtd/dislike.html:74
+#: templates/django_comments_xtd/like.html:73
+msgid "cancel"
+msgstr "annuleer"
 
 #: templates/comments/deleted.html:5
 msgid "Comment removed"
@@ -120,12 +157,6 @@ msgstr "Aan "
 msgid "Flag"
 msgstr "Markeer"
 
-#: templates/comments/flag.html:57
-#: templates/django_comments_xtd/dislike.html:74
-#: templates/django_comments_xtd/like.html:73
-msgid "cancel"
-msgstr "annuleer"
-
 #: templates/comments/flagged.html:5
 msgid "Comment flagged"
 msgstr "Reactie gemarkeerd"
@@ -143,7 +174,7 @@ msgid "preview"
 msgstr "voorbeeld"
 
 #: templates/comments/list.html:25
-#: templates/django_comments_xtd/comment_tree.html:43
+#: templates/django_comments_xtd/comment_tree.html:45
 msgid "Reply"
 msgstr "Beantwoorden..."
 
@@ -157,8 +188,13 @@ msgid ""
 "            email address. Please, click on the link in the message to "
 "confirm\n"
 "            your comment."
-msgstr "Er is een bevestigingsbericht gestuurd naar uw e-mailadres.\n"
+msgstr ""
+"Er is een bevestigingsbericht gestuurd naar uw e-mailadres.\n"
 "Klik op de link in het bericht om uw reactie te bevestigen"
+
+#: templates/comments/posted.html:17
+msgid "Go back to"
+msgstr ""
 
 #: templates/comments/preview.html:5 templates/comments/preview.html:10
 msgid "Preview your comment"
@@ -172,7 +208,7 @@ msgstr "Voorbeeldweergave van uw reactie op:"
 msgid "Empty comment."
 msgstr "Lege reactie"
 
-#: templates/comments/preview.html:41
+#: templates/comments/preview.html:48
 #: templates/django_comments_xtd/reply.html:32
 msgid "Post your comment"
 msgstr "Plaats uw reactie"
@@ -181,22 +217,28 @@ msgstr "Plaats uw reactie"
 msgid "List of comments"
 msgstr "Reacties"
 
-#: templates/django_comments_xtd/comment_tree.html:13
+#: templates/django_comments_xtd/comment_list.html:21
+#, fuzzy
+#| msgid "Your comment"
+msgid "No comments yet."
+msgstr "Uw reactie"
+
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "moderator"
 msgstr "beheerder"
 
-#: templates/django_comments_xtd/comment_tree.html:13
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "comment permalink"
 msgstr "permalink"
 
-#: templates/django_comments_xtd/comment_tree.html:18
+#: templates/django_comments_xtd/comment_tree.html:17
 #, python-format
 msgid "A user has flagged this comment as inappropriate."
 msgid_plural "%(counter)s users have flagged this comment as inappropriate."
 msgstr[0] "Een gebruiker heeft deze reactie als ongepast gemarkeerd."
 msgstr[1] "%(counter)s gebruikers hebben dit bericht als ongepast gemarkeerd."
 
-#: templates/django_comments_xtd/comment_tree.html:22
+#: templates/django_comments_xtd/comment_tree.html:21
 msgid "comment flagged"
 msgstr "reactie gemarkeerd"
 
@@ -204,7 +246,7 @@ msgstr "reactie gemarkeerd"
 msgid "flag comment"
 msgstr "markeer reactie"
 
-#: templates/django_comments_xtd/comment_tree.html:28
+#: templates/django_comments_xtd/comment_tree.html:30
 msgid "remove comment"
 msgstr "verwijder reactie"
 
@@ -262,13 +304,72 @@ msgstr "U vindt deze reactie niet leuk"
 msgid "Thanks for taking the time to participate."
 msgstr "Bedankt dat actief deelneemt."
 
+#: templates/django_comments_xtd/email_confirmation_request.html:3
+#: templates/django_comments_xtd/email_confirmation_request.txt:3
+msgid ""
+"You or someone in behalf of you have requested to post a comment into this "
+"page:"
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:7
+#: templates/django_comments_xtd/email_followup_comment.html:8
+#, fuzzy
+#| msgid "Remove comment"
+msgid "The comment"
+msgstr "Verwijder reactie"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:11
+#: templates/django_comments_xtd/email_confirmation_request.txt:11
+#, python-format
+msgid ""
+"If you do not wish to post the comment, please ignore this message or report "
+"an incident to %(contact)s. Otherwise click on the link below to confirm the "
+"comment."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:15
+#: templates/django_comments_xtd/email_confirmation_request.txt:15
+msgid ""
+"If clicking does not work, you can also copy and paste the address into your "
+"browser's address window."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:17
+#: templates/django_comments_xtd/email_confirmation_request.txt:16
+#, fuzzy
+#| msgid "Post your comment"
+msgid "Thanks for your comment!"
+msgstr "Plaats uw reactie"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:19
+#: templates/django_comments_xtd/email_confirmation_request.txt:19
+#: templates/django_comments_xtd/email_followup_comment.html:14
+#: templates/django_comments_xtd/email_followup_comment.txt:20
+msgid "Kind regards"
+msgstr "Met vriendelijke groet,"
+
+#: templates/django_comments_xtd/email_followup_comment.html:3
 #: templates/django_comments_xtd/email_followup_comment.txt:4
 msgid "There is a new comment following up yours."
 msgstr "Er is een nieuw antwoord op jouw reactie geplaatst."
 
-#: templates/django_comments_xtd/email_followup_comment.txt:20
-msgid "Kind regards"
-msgstr "Met vriendelijke groet,"
+#: templates/django_comments_xtd/email_followup_comment.html:12
+#, python-format
+msgid ""
+"Click <a href=\"http://%(site_domain)s%(mute_url)s\">http://%(site_domain)s"
+"%(mute_url_short)s...</a> to mute the comments thread. You will no longer "
+"receive follow-up notifications."
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:6
+msgid "Post"
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:15
+msgid ""
+"Click on the following link to mute the comments thread. You will no longer "
+"receive follow-up notifications:"
+msgstr ""
 
 #: templates/django_comments_xtd/like.html:15
 msgid "You liked this comment, do you want to change it?"
@@ -310,7 +411,8 @@ msgid ""
 msgstr ""
 "\n"
 "            Uw reactie wacht op goedkeuring door de beheerder.<br/>\n"
-"            De inhoud wordt gecontroleerd voordat het gepubliceerd mag worden.<br/>\n"
+"            De inhoud wordt gecontroleerd voordat het gepubliceerd mag "
+"worden.<br/>\n"
 "            Bedankt voor uw geduld en begrip.\n"
 "            "
 
@@ -326,6 +428,7 @@ msgstr ""
 "            Terug naar: <a href=\"%(content_object_url)s\">"
 "%(content_object_str)s</a>\n"
 "            "
+
 #: templates/django_comments_xtd/muted.html:4
 msgid "Comment thread muted"
 msgstr "Discussie gedempd"
@@ -337,8 +440,24 @@ msgstr "Reacties op deze discussies worden gedempd"
 #: templates/django_comments_xtd/muted.html:9
 msgid "You will no longer receive email notifications for comments sent to"
 msgstr ""
-"U ontvangt geen nieuwe notificaties per e-mail als er reacties door anderen"
-" geplaatst worden."
+"U ontvangt geen nieuwe notificaties per e-mail als er reacties door anderen "
+"geplaatst worden."
+
+#: templates/django_comments_xtd/only_users_can_post.html:5
+msgid "Only registered users can post comments."
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:1
+msgid "A removal suggestion has been received for the following comment:"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:7
+msgid "Posted to the following URL"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:10
+msgid "Removal suggested by"
+msgstr ""
 
 #: templates/django_comments_xtd/reply.html:6
 msgid "Comment reply"
@@ -348,10 +467,28 @@ msgstr "Beantwoorden"
 msgid "Reply to comment"
 msgstr "Beantwoord deze reactie"
 
-#: views.py:49
+#: tests/apiauth.py:17
+msgid "Invalid token header. No credentials provided."
+msgstr ""
+
+#: tests/apiauth.py:20
+msgid "Invalid token header.Token string should not contain spaces."
+msgstr ""
+
+#: tests/apiauth.py:27
+msgid ""
+"Invalid token header. Token string should not contain invalid characters."
+msgstr ""
+
+#: views.py:60
 msgid "comment confirmation request"
 msgstr "reactiebevestiging gestuurd"
 
-#: views.py:212
+#: views.py:278
 msgid "new comment posted"
 msgstr "Nieuw reactie geplaatst."
+
+#, fuzzy
+#~| msgid "Kind regards"
+#~ msgid "Kind regards,"
+#~ msgstr "Met vriendelijke groet,"

--- a/django_comments_xtd/locale/no/LC_MESSAGES/django.po
+++ b/django_comments_xtd/locale/no/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-11 14:17+0100\n"
+"POT-Creation-Date: 2022-09-17 23:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,9 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: api/serializers.py:192 templates/comments/list.html:17
-#: templates/django_comments_xtd/comment.html:14
-#: templates/django_comments_xtd/comment_tree.html:34
+#: api/serializers.py:277 templates/comments/list.html:17
+#: templates/django_comments_xtd/comment.html:15
+#: templates/django_comments_xtd/comment_tree.html:36
 msgid "This comment has been removed."
 msgstr "Denne kommentaren har blitt fjernet."
 
@@ -28,41 +28,70 @@ msgstr "Denne kommentaren har blitt fjernet."
 msgid "Notify me about follow-up comments"
 msgstr "Varsle meg om svar"
 
-#: forms.py:28
+#: forms.py:29
 msgid "Name"
 msgstr "Navn"
 
-#: forms.py:29
+#: forms.py:31
 msgid "name"
 msgstr "navn"
 
-#: forms.py:32
+#: forms.py:33
 msgid "Mail"
 msgstr "E-post"
 
-#: forms.py:32
+#: forms.py:34
 msgid "Required for comment verification"
 msgstr "Påkrevet for å bekrefte kommentarer"
 
-#: forms.py:33
+#: forms.py:36
 msgid "mail address"
 msgstr "e-postadresse"
 
-#: forms.py:36
+#: forms.py:38
 msgid "Link"
 msgstr "Link"
 
-#: forms.py:38
+#: forms.py:41
 msgid "url your name links to (optional)"
 msgstr "URL som navnet ditt linker til (valgfritt)"
 
-#: forms.py:41
+#: forms.py:45
 msgid "Your comment"
 msgstr "Din kommentar"
 
-#: models.py:70
+#: models.py:68
 msgid "Notify follow-up comments"
 msgstr "Varsle om svar"
+
+#: templates/404.html:9
+msgid "Page not found"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:1
+msgid "A new comment has been sent to the following URL:"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:5
+#: templates/django_comments_xtd/email_followup_comment.html:5
+#: templates/django_comments_xtd/email_followup_comment.txt:8
+msgid "Sent by"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:6
+#, fuzzy
+#| msgid "mail address"
+msgid "Email address"
+msgstr "e-postadresse"
+
+#: templates/comments/comment_notification_email.txt:8
+#: templates/django_comments_xtd/email_confirmation_request.txt:7
+#: templates/django_comments_xtd/email_followup_comment.txt:10
+#: templates/django_comments_xtd/removal_notification_email.txt:3
+#, fuzzy
+#| msgid "Comment reply"
+msgid "Comment"
+msgstr "Tilsvar"
 
 #: templates/comments/delete.html:5
 msgid "Remove comment"
@@ -81,9 +110,15 @@ msgstr ""
 "Som moderator kan du fjerne kommentarer. Kommentarer slettes ikke fra siden, "
 "men teksten skjules. Klikk på fjerneknappen for å fjerne følgende kommentar:"
 
-#: templates/comments/delete.html:41
+#: templates/comments/delete.html:45
 msgid "Remove"
 msgstr "Fjern"
+
+#: templates/comments/delete.html:46 templates/comments/flag.html:57
+#: templates/django_comments_xtd/dislike.html:74
+#: templates/django_comments_xtd/like.html:73
+msgid "cancel"
+msgstr "Avbryt"
 
 #: templates/comments/deleted.html:5
 msgid "Comment removed"
@@ -97,8 +132,7 @@ msgstr "Denne kommentaren har blitt fjernet."
 msgid ""
 "Thank you for taking the time to improve the quality of discussion in our "
 "site."
-msgstr ""
-"Takk for at du tok deg tid til å forbedre diskusjonen på siden vår."
+msgstr "Takk for at du tok deg tid til å forbedre diskusjonen på siden vår."
 
 #: templates/comments/flag.html:5
 msgid "Flag comment"
@@ -114,22 +148,16 @@ msgid ""
 msgstr ""
 "Klikk på rapporteringsknappen for å markere kommentaren som upassende.."
 
-#: templates/comments/flag.html:40
-#: templates/django_comments_xtd/comment.html:10
-#: templates/django_comments_xtd/dislike.html:48
-#: templates/django_comments_xtd/like.html:46
+#: templates/comments/flag.html:41
+#: templates/django_comments_xtd/comment.html:11
+#: templates/django_comments_xtd/dislike.html:49
+#: templates/django_comments_xtd/like.html:47
 msgid "Posted to "
 msgstr "Lagt til på"
 
-#: templates/comments/flag.html:55
+#: templates/comments/flag.html:56
 msgid "Flag"
 msgstr "Rapporter"
-
-#: templates/comments/flag.html:56
-#: templates/django_comments_xtd/dislike.html:73
-#: templates/django_comments_xtd/like.html:72
-msgid "cancel"
-msgstr "Avbryt"
 
 #: templates/comments/flagged.html:5
 msgid "Comment flagged"
@@ -148,7 +176,7 @@ msgid "preview"
 msgstr "forhåndsvis"
 
 #: templates/comments/list.html:25
-#: templates/django_comments_xtd/comment_tree.html:43
+#: templates/django_comments_xtd/comment_tree.html:45
 msgid "Reply"
 msgstr "Svar"
 
@@ -163,8 +191,12 @@ msgid ""
 "confirm\n"
 "            your comment."
 msgstr ""
-"En bekreftelsesmelding har blitt sendt til e-postadressen din. "
-"Vennligst klikk på linken i meldingen for å bekrefte kommentaren."
+"En bekreftelsesmelding har blitt sendt til e-postadressen din. Vennligst "
+"klikk på linken i meldingen for å bekrefte kommentaren."
+
+#: templates/comments/posted.html:17
+msgid "Go back to"
+msgstr ""
 
 #: templates/comments/preview.html:5 templates/comments/preview.html:10
 msgid "Preview your comment"
@@ -178,7 +210,7 @@ msgstr "Forhåndsvis kommentaren din for:"
 msgid "Empty comment."
 msgstr "Tom kommentar"
 
-#: templates/comments/preview.html:41
+#: templates/comments/preview.html:48
 #: templates/django_comments_xtd/reply.html:32
 msgid "Post your comment"
 msgstr "Legg inn din kommentar"
@@ -187,22 +219,28 @@ msgstr "Legg inn din kommentar"
 msgid "List of comments"
 msgstr "Liste over kommentarer"
 
-#: templates/django_comments_xtd/comment_tree.html:13
+#: templates/django_comments_xtd/comment_list.html:21
+#, fuzzy
+#| msgid "Your comment"
+msgid "No comments yet."
+msgstr "Din kommentar"
+
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "moderator"
 msgstr "moderator"
 
-#: templates/django_comments_xtd/comment_tree.html:13
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "comment permalink"
 msgstr "Permanent link"
 
-#: templates/django_comments_xtd/comment_tree.html:18
+#: templates/django_comments_xtd/comment_tree.html:17
 #, python-format
 msgid "A user has flagged this comment as inappropriate."
 msgid_plural "%(counter)s users have flagged this comment as inappropriate."
 msgstr[0] "En bruker har rapportert denne kommentaren som upassende."
 msgstr[1] "%(counter)s brukere har rapportert denne kommentaren som upassende."
 
-#: templates/django_comments_xtd/comment_tree.html:22
+#: templates/django_comments_xtd/comment_tree.html:21
 msgid "comment flagged"
 msgstr "kommentar rapportert"
 
@@ -210,7 +248,7 @@ msgstr "kommentar rapportert"
 msgid "flag comment"
 msgstr "rapporter kommentar"
 
-#: templates/django_comments_xtd/comment_tree.html:28
+#: templates/django_comments_xtd/comment_tree.html:30
 msgid "remove comment"
 msgstr "fjern kommentar"
 
@@ -244,21 +282,20 @@ msgstr "Misliker du denne kommentaren?"
 msgid "Please, confirm your opinion about the comment."
 msgstr "Vennligst bekreft din mening om kommentaren."
 
-#: templates/django_comments_xtd/dislike.html:61
+#: templates/django_comments_xtd/dislike.html:62
 msgid ""
 "Click on the \"withdraw\" button if you want to withdraw your negative "
 "opinion on this comment."
 msgstr ""
-"Klikk på avbryt-knappen hvis du vil trekke din negative tilbakemelding "
-"til denne kommentaren."
+"Klikk på avbryt-knappen hvis du vil trekke din negative tilbakemelding til "
+"denne kommentaren."
 
-
-#: templates/django_comments_xtd/dislike.html:69
-#: templates/django_comments_xtd/like.html:68
+#: templates/django_comments_xtd/dislike.html:70
+#: templates/django_comments_xtd/like.html:69
 msgid "Withdraw"
 msgstr "Avbryt"
 
-#: templates/django_comments_xtd/dislike.html:71
+#: templates/django_comments_xtd/dislike.html:72
 msgid "I dislike it"
 msgstr "Jeg misliker den"
 
@@ -271,13 +308,72 @@ msgstr "Du mislikte kommentaren"
 msgid "Thanks for taking the time to participate."
 msgstr "Takk for at du deltar."
 
+#: templates/django_comments_xtd/email_confirmation_request.html:3
+#: templates/django_comments_xtd/email_confirmation_request.txt:3
+msgid ""
+"You or someone in behalf of you have requested to post a comment into this "
+"page:"
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:7
+#: templates/django_comments_xtd/email_followup_comment.html:8
+#, fuzzy
+#| msgid "Remove comment"
+msgid "The comment"
+msgstr "Fjern kommentar"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:11
+#: templates/django_comments_xtd/email_confirmation_request.txt:11
+#, python-format
+msgid ""
+"If you do not wish to post the comment, please ignore this message or report "
+"an incident to %(contact)s. Otherwise click on the link below to confirm the "
+"comment."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:15
+#: templates/django_comments_xtd/email_confirmation_request.txt:15
+msgid ""
+"If clicking does not work, you can also copy and paste the address into your "
+"browser's address window."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:17
+#: templates/django_comments_xtd/email_confirmation_request.txt:16
+#, fuzzy
+#| msgid "Post your comment"
+msgid "Thanks for your comment!"
+msgstr "Legg inn din kommentar"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:19
+#: templates/django_comments_xtd/email_confirmation_request.txt:19
+#: templates/django_comments_xtd/email_followup_comment.html:14
+#: templates/django_comments_xtd/email_followup_comment.txt:20
+msgid "Kind regards"
+msgstr "Med vennlig hilsen"
+
+#: templates/django_comments_xtd/email_followup_comment.html:3
 #: templates/django_comments_xtd/email_followup_comment.txt:4
 msgid "There is a new comment following up yours."
 msgstr "Din kommentar har fått et nytt svar."
 
-#: templates/django_comments_xtd/email_followup_comment.txt:20
-msgid "Kind regards"
-msgstr "Med vennlig hilsen"
+#: templates/django_comments_xtd/email_followup_comment.html:12
+#, python-format
+msgid ""
+"Click <a href=\"http://%(site_domain)s%(mute_url)s\">http://%(site_domain)s"
+"%(mute_url_short)s...</a> to mute the comments thread. You will no longer "
+"receive follow-up notifications."
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:6
+msgid "Post"
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:15
+msgid ""
+"Click on the following link to mute the comments thread. You will no longer "
+"receive follow-up notifications:"
+msgstr ""
 
 #: templates/django_comments_xtd/like.html:15
 msgid "You liked this comment, do you want to change it?"
@@ -287,7 +383,7 @@ msgstr "Du likte denne kommentaren. Vil du endre den?"
 msgid "Do you like this comment?"
 msgstr "Vil du like denne kommentaren?"
 
-#: templates/django_comments_xtd/like.html:59
+#: templates/django_comments_xtd/like.html:60
 msgid ""
 "Click on the \"withdraw\" button if you want to withdraw your positive "
 "opinion on this comment."
@@ -295,8 +391,7 @@ msgstr ""
 "Klikk på avbryt-knappen hvis du vil trekke tilbake din positive "
 "tilbakemelding til denne kommentaren."
 
-
-#: templates/django_comments_xtd/like.html:70
+#: templates/django_comments_xtd/like.html:71
 msgid "I like it"
 msgstr "Jeg liker den"
 
@@ -349,7 +444,24 @@ msgstr "Kommentartråden har blitt dempet"
 
 #: templates/django_comments_xtd/muted.html:9
 msgid "You will no longer receive email notifications for comments sent to"
-msgstr "Du kommer ikke lenger til å motta e-postvarsler om kommentarer sent til"
+msgstr ""
+"Du kommer ikke lenger til å motta e-postvarsler om kommentarer sent til"
+
+#: templates/django_comments_xtd/only_users_can_post.html:5
+msgid "Only registered users can post comments."
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:1
+msgid "A removal suggestion has been received for the following comment:"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:7
+msgid "Posted to the following URL"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:10
+msgid "Removal suggested by"
+msgstr ""
 
 #: templates/django_comments_xtd/reply.html:6
 msgid "Comment reply"
@@ -359,10 +471,28 @@ msgstr "Tilsvar"
 msgid "Reply to comment"
 msgstr "Svar på kommentar"
 
-#: views.py:49
+#: tests/apiauth.py:17
+msgid "Invalid token header. No credentials provided."
+msgstr ""
+
+#: tests/apiauth.py:20
+msgid "Invalid token header.Token string should not contain spaces."
+msgstr ""
+
+#: tests/apiauth.py:27
+msgid ""
+"Invalid token header. Token string should not contain invalid characters."
+msgstr ""
+
+#: views.py:60
 msgid "comment confirmation request"
 msgstr "bekreftelsesforespørsel"
 
-#: views.py:212
+#: views.py:278
 msgid "new comment posted"
 msgstr "ny kommentar lagt inn"
+
+#, fuzzy
+#~| msgid "Kind regards"
+#~ msgid "Kind regards,"
+#~ msgstr "Med vennlig hilsen"

--- a/django_comments_xtd/locale/ru/LC_MESSAGES/django.po
+++ b/django_comments_xtd/locale/ru/LC_MESSAGES/django.po
@@ -8,246 +8,288 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-08 11:50+0300\n"
+"POT-Creation-Date: 2022-09-17 23:38+0200\n"
 "PO-Revision-Date: 2020-06-08 12:10+0053\n"
 "Last-Translator: b'Administrator  <admin@example.com>'\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
 "X-Translated-Using: django-rosetta 0.9.4\n"
 
-#: .\api\serializers.py:242 .\templates\comments\list.html:17
-#: .\templates\django_comments_xtd\comment.html:15
-#: .\templates\django_comments_xtd\comment_tree.html:34
+#: api/serializers.py:277 templates/comments/list.html:17
+#: templates/django_comments_xtd/comment.html:15
+#: templates/django_comments_xtd/comment_tree.html:36
 msgid "This comment has been removed."
 msgstr "Комментарий был удален"
 
-#: .\forms.py:13
+#: forms.py:13
 msgid "Notify me about follow-up comments"
 msgstr "Сообщить об ответных комментариях"
 
-#: .\forms.py:28
+#: forms.py:29
 msgid "Name"
 msgstr "Имя"
 
-#: .\forms.py:29
+#: forms.py:31
 msgid "name"
 msgstr "имя"
 
-#: .\forms.py:32
+#: forms.py:33
 msgid "Mail"
 msgstr "Почта"
 
-#: .\forms.py:32
+#: forms.py:34
 msgid "Required for comment verification"
 msgstr "Необходима для подтверждения комментария"
 
-#: .\forms.py:33
+#: forms.py:36
 msgid "mail address"
 msgstr "почтовый адрес"
 
-#: .\forms.py:36
+#: forms.py:38
 msgid "Link"
 msgstr "Ссылка"
 
-#: .\forms.py:38
+#: forms.py:41
 msgid "url your name links to (optional)"
 msgstr "ссылка, на которую ведет Ваше имя (не обязательно)"
 
-#: .\forms.py:41
+#: forms.py:45
 msgid "Your comment"
 msgstr "Ваш комментарий"
 
-#: .\models.py:70
+#: models.py:68
 msgid "Notify follow-up comments"
 msgstr "Уведомлять о последующих комментариях"
 
-#: .\templates\comments\delete.html:5
+#: templates/404.html:9
+msgid "Page not found"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:1
+msgid "A new comment has been sent to the following URL:"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:5
+#: templates/django_comments_xtd/email_followup_comment.html:5
+#: templates/django_comments_xtd/email_followup_comment.txt:8
+msgid "Sent by"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:6
+#, fuzzy
+#| msgid "mail address"
+msgid "Email address"
+msgstr "почтовый адрес"
+
+#: templates/comments/comment_notification_email.txt:8
+#: templates/django_comments_xtd/email_confirmation_request.txt:7
+#: templates/django_comments_xtd/email_followup_comment.txt:10
+#: templates/django_comments_xtd/removal_notification_email.txt:3
+#, fuzzy
+#| msgid "Comment reply"
+msgid "Comment"
+msgstr "Ответ на комментарий"
+
+#: templates/comments/delete.html:5
 msgid "Remove comment"
 msgstr "Удалить комментарий"
 
-#: .\templates\comments\delete.html:9
+#: templates/comments/delete.html:9
 msgid "Remove this comment?"
 msgstr "Удалить комментарий?"
 
-#: .\templates\comments\delete.html:12
+#: templates/comments/delete.html:12
 msgid ""
 "As a moderator you can delete comments. Deleting a comment does not remove "
-"it from the site, only prevents your website from showing the text. Click on"
-" the remove button to delete the following comment:"
+"it from the site, only prevents your website from showing the text. Click on "
+"the remove button to delete the following comment:"
 msgstr ""
 "Как модератор, Вы можете удалять комментарий. Удаление комментария уберет "
 "его с сайта, но он будет доступен в администраторской панели. Нажмите "
 "\"Удалить\", чтобы удалить следующий комментарий:"
 
-#: .\templates\comments\delete.html:41
+#: templates/comments/delete.html:45
 msgid "Remove"
 msgstr "Удалить"
 
-#: .\templates\comments\deleted.html:5
+#: templates/comments/delete.html:46 templates/comments/flag.html:57
+#: templates/django_comments_xtd/dislike.html:74
+#: templates/django_comments_xtd/like.html:73
+msgid "cancel"
+msgstr "отмена"
+
+#: templates/comments/deleted.html:5
 msgid "Comment removed"
 msgstr "Комментарий удален"
 
-#: .\templates\comments\deleted.html:12
+#: templates/comments/deleted.html:12
 msgid "The comment has been removed."
 msgstr "Комментарий удален"
 
-#: .\templates\comments\deleted.html:13 .\templates\comments\flagged.html:13
+#: templates/comments/deleted.html:13 templates/comments/flagged.html:13
 msgid ""
 "Thank you for taking the time to improve the quality of discussion in our "
 "site."
 msgstr "Спасибо за Ваш вклад в улучшение качества общения на этом сайте"
 
-#: .\templates\comments\flag.html:5
+#: templates/comments/flag.html:5
 msgid "Flag comment"
 msgstr "Пометить комментарий"
 
-#: .\templates\comments\flag.html:13
+#: templates/comments/flag.html:13
 msgid "Flag this comment?"
 msgstr "Пометить комментарий?"
 
-#: .\templates\comments\flag.html:16
+#: templates/comments/flag.html:16
 msgid ""
 "Click on the flag button to mark the following comment as inappropriate."
 msgstr ""
 "Нажмите на кнопку с флагом, чтобы пометить этот комментарий, как "
 "некорректный."
 
-#: .\templates\comments\flag.html:41
-#: .\templates\django_comments_xtd\comment.html:11
-#: .\templates\django_comments_xtd\dislike.html:49
-#: .\templates\django_comments_xtd\like.html:47
+#: templates/comments/flag.html:41
+#: templates/django_comments_xtd/comment.html:11
+#: templates/django_comments_xtd/dislike.html:49
+#: templates/django_comments_xtd/like.html:47
 msgid "Posted to "
 msgstr "Размещено в"
 
-#: .\templates\comments\flag.html:56
+#: templates/comments/flag.html:56
 msgid "Flag"
 msgstr "Флаг"
 
-#: .\templates\comments\flag.html:57
-#: .\templates\django_comments_xtd\dislike.html:74
-#: .\templates\django_comments_xtd\like.html:73
-msgid "cancel"
-msgstr "отмена"
-
-#: .\templates\comments\flagged.html:5
+#: templates/comments/flagged.html:5
 msgid "Comment flagged"
 msgstr "Комментарий помечен"
 
-#: .\templates\comments\flagged.html:12
+#: templates/comments/flagged.html:12
 msgid "The comment has been flagged."
 msgstr "Комментарий помечен"
 
-#: .\templates\comments\form.html:70
+#: templates/comments/form.html:70
 msgid "send"
 msgstr "отправить"
 
-#: .\templates\comments\form.html:71
+#: templates/comments/form.html:71
 msgid "preview"
 msgstr "предпросмотр"
 
-#: .\templates\comments\list.html:25
-#: .\templates\django_comments_xtd\comment_tree.html:43
+#: templates/comments/list.html:25
+#: templates/django_comments_xtd/comment_tree.html:45
 msgid "Reply"
 msgstr "Ответить"
 
-#: .\templates\comments\posted.html:6
+#: templates/comments/posted.html:6
 msgid "Comment confirmation requested."
 msgstr "Необходимо подтверждение комментария"
 
-#: .\templates\comments\posted.html:12
+#: templates/comments/posted.html:12
 msgid ""
 "A confirmation message has been sent to your\n"
-"            email address. Please, click on the link in the message to confirm\n"
+"            email address. Please, click on the link in the message to "
+"confirm\n"
 "            your comment."
 msgstr ""
 "На ваш адрес электронной почты было отправлено сообщение со ссылкой для "
 "подтверждения. Пожалуйста, пройдите по ссылке, чтобы верифицировать "
 "комментарий."
 
-#: .\templates\comments\preview.html:5 .\templates\comments\preview.html:10
+#: templates/comments/posted.html:17
+msgid "Go back to"
+msgstr ""
+
+#: templates/comments/preview.html:5 templates/comments/preview.html:10
 msgid "Preview your comment"
 msgstr "Предпросмотр комментария"
 
-#: .\templates\comments\preview.html:14
+#: templates/comments/preview.html:14
 msgid "Preview of your comment for:"
 msgstr "Предпросмотр комментария для:"
 
-#: .\templates\comments\preview.html:21
+#: templates/comments/preview.html:21
 msgid "Empty comment."
 msgstr "Пустой комментарий."
 
-#: .\templates\comments\preview.html:41
-#: .\templates\django_comments_xtd\reply.html:32
+#: templates/comments/preview.html:48
+#: templates/django_comments_xtd/reply.html:32
 msgid "Post your comment"
 msgstr "Оставить комментарий"
 
-#: .\templates\django_comments_xtd\comment_list.html:11
+#: templates/django_comments_xtd/comment_list.html:11
 msgid "List of comments"
 msgstr "Список комментариев"
 
-#: .\templates\django_comments_xtd\comment_tree.html:13
+#: templates/django_comments_xtd/comment_list.html:21
+#, fuzzy
+#| msgid "Your comment"
+msgid "No comments yet."
+msgstr "Ваш комментарий"
+
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "moderator"
 msgstr "модератор"
 
-#: .\templates\django_comments_xtd\comment_tree.html:13
+#: templates/django_comments_xtd/comment_tree.html:12
 msgid "comment permalink"
 msgstr "ссылка на комментарий"
 
-#: .\templates\django_comments_xtd\comment_tree.html:18
+#: templates/django_comments_xtd/comment_tree.html:17
 #, python-format
 msgid "A user has flagged this comment as inappropriate."
 msgid_plural "%(counter)s users have flagged this comment as inappropriate."
-msgstr[0] ""
-"%(counter)s пользователь отметил этот комментарий как некорректный."
+msgstr[0] "%(counter)s пользователь отметил этот комментарий как некорректный."
 msgstr[1] ""
 "%(counter)s пользователей отметили этот комментарий как некорректный."
 
-#: .\templates\django_comments_xtd\comment_tree.html:22
+#: templates/django_comments_xtd/comment_tree.html:21
 msgid "comment flagged"
 msgstr "Комментарий помечен"
 
-#: .\templates\django_comments_xtd\comment_tree.html:25
+#: templates/django_comments_xtd/comment_tree.html:25
 msgid "flag comment"
 msgstr "Пометить комментарий"
 
-#: .\templates\django_comments_xtd\comment_tree.html:28
+#: templates/django_comments_xtd/comment_tree.html:30
 msgid "remove comment"
 msgstr "удалить комментарий"
 
-#: .\templates\django_comments_xtd\discarded.html:4
+#: templates/django_comments_xtd/discarded.html:4
 msgid "Comment discarded"
 msgstr "Комментарий отклонен"
 
-#: .\templates\django_comments_xtd\discarded.html:7
+#: templates/django_comments_xtd/discarded.html:7
 msgid "Comment automatically discarded"
 msgstr "Комментарий автоматически отклонен"
 
-#: .\templates\django_comments_xtd\discarded.html:8
+#: templates/django_comments_xtd/discarded.html:8
 msgid "Sorry, your comment has been automatically discarded"
 msgstr "К сожалению, Ваш комментарий был автоматически отклонён"
 
-#: .\templates\django_comments_xtd\dislike.html:5
-#: .\templates\django_comments_xtd\like.html:5
+#: templates/django_comments_xtd/dislike.html:5
+#: templates/django_comments_xtd/like.html:5
 msgid "Confirm your opinion"
 msgstr "Подтвердите Ваш выбор"
 
-#: .\templates\django_comments_xtd\dislike.html:15
+#: templates/django_comments_xtd/dislike.html:15
 msgid "You didn't like this comment, do you want to change it?"
 msgstr "Вам не понравился комментарий, не хотите его поменять?"
 
-#: .\templates\django_comments_xtd\dislike.html:17
+#: templates/django_comments_xtd/dislike.html:17
 msgid "Do you dislike this comment?"
 msgstr "Вам не понравился комментарий?"
 
-#: .\templates\django_comments_xtd\dislike.html:22
-#: .\templates\django_comments_xtd\like.html:22
+#: templates/django_comments_xtd/dislike.html:22
+#: templates/django_comments_xtd/like.html:22
 msgid "Please, confirm your opinion about the comment."
 msgstr "Пожалуйста, подтвердите Ваш выбор насчет комментария."
 
-#: .\templates\django_comments_xtd\dislike.html:62
+#: templates/django_comments_xtd/dislike.html:62
 msgid ""
 "Click on the \"withdraw\" button if you want to withdraw your negative "
 "opinion on this comment."
@@ -255,42 +297,101 @@ msgstr ""
 "Нажмите на кнопку \"отозвать\", чтобы поменять Ваш выбор относительно "
 "данного комментария."
 
-#: .\templates\django_comments_xtd\dislike.html:70
-#: .\templates\django_comments_xtd\like.html:69
+#: templates/django_comments_xtd/dislike.html:70
+#: templates/django_comments_xtd/like.html:69
 msgid "Withdraw"
 msgstr "Отозвать"
 
-#: .\templates\django_comments_xtd\dislike.html:72
+#: templates/django_comments_xtd/dislike.html:72
 msgid "I dislike it"
 msgstr "Мне это не нравится"
 
-#: .\templates\django_comments_xtd\disliked.html:4
+#: templates/django_comments_xtd/disliked.html:4
 #, fuzzy
 msgid "You disliked the comment"
 msgstr "Вы поставили комментарию \"дизлайк\""
 
-#: .\templates\django_comments_xtd\disliked.html:7
-#: .\templates\django_comments_xtd\liked.html:7
+#: templates/django_comments_xtd/disliked.html:7
+#: templates/django_comments_xtd/liked.html:7
 msgid "Thanks for taking the time to participate."
 msgstr "Спасибо за участие."
 
-#: .\templates\django_comments_xtd\email_followup_comment.txt:4
-msgid "There is a new comment following up yours."
-msgstr "Появился ответный комментарий."
+#: templates/django_comments_xtd/email_confirmation_request.html:3
+#: templates/django_comments_xtd/email_confirmation_request.txt:3
+msgid ""
+"You or someone in behalf of you have requested to post a comment into this "
+"page:"
+msgstr ""
 
-#: .\templates\django_comments_xtd\email_followup_comment.txt:20
+#: templates/django_comments_xtd/email_confirmation_request.html:7
+#: templates/django_comments_xtd/email_followup_comment.html:8
+#, fuzzy
+#| msgid "Remove comment"
+msgid "The comment"
+msgstr "Удалить комментарий"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:11
+#: templates/django_comments_xtd/email_confirmation_request.txt:11
+#, python-format
+msgid ""
+"If you do not wish to post the comment, please ignore this message or report "
+"an incident to %(contact)s. Otherwise click on the link below to confirm the "
+"comment."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:15
+#: templates/django_comments_xtd/email_confirmation_request.txt:15
+msgid ""
+"If clicking does not work, you can also copy and paste the address into your "
+"browser's address window."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:17
+#: templates/django_comments_xtd/email_confirmation_request.txt:16
+#, fuzzy
+#| msgid "Post your comment"
+msgid "Thanks for your comment!"
+msgstr "Оставить комментарий"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:19
+#: templates/django_comments_xtd/email_confirmation_request.txt:19
+#: templates/django_comments_xtd/email_followup_comment.html:14
+#: templates/django_comments_xtd/email_followup_comment.txt:20
 msgid "Kind regards"
 msgstr "С уважением"
 
-#: .\templates\django_comments_xtd\like.html:15
+#: templates/django_comments_xtd/email_followup_comment.html:3
+#: templates/django_comments_xtd/email_followup_comment.txt:4
+msgid "There is a new comment following up yours."
+msgstr "Появился ответный комментарий."
+
+#: templates/django_comments_xtd/email_followup_comment.html:12
+#, python-format
+msgid ""
+"Click <a href=\"http://%(site_domain)s%(mute_url)s\">http://%(site_domain)s"
+"%(mute_url_short)s...</a> to mute the comments thread. You will no longer "
+"receive follow-up notifications."
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:6
+msgid "Post"
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:15
+msgid ""
+"Click on the following link to mute the comments thread. You will no longer "
+"receive follow-up notifications:"
+msgstr ""
+
+#: templates/django_comments_xtd/like.html:15
 msgid "You liked this comment, do you want to change it?"
 msgstr "Вам понравился комментарий, хотите изменить выбор?"
 
-#: .\templates\django_comments_xtd\like.html:17
+#: templates/django_comments_xtd/like.html:17
 msgid "Do you like this comment?"
 msgstr "Вам нравится комментарий?"
 
-#: .\templates\django_comments_xtd\like.html:60
+#: templates/django_comments_xtd/like.html:60
 msgid ""
 "Click on the \"withdraw\" button if you want to withdraw your positive "
 "opinion on this comment."
@@ -298,23 +399,23 @@ msgstr ""
 "Нажмите на кнопку \"отозвать\", чтобы поменять Ваш выбор относительно "
 "данного комментария."
 
-#: .\templates\django_comments_xtd\like.html:71
+#: templates/django_comments_xtd/like.html:71
 msgid "I like it"
 msgstr "Мне это нравится"
 
-#: .\templates\django_comments_xtd\liked.html:4
+#: templates/django_comments_xtd/liked.html:4
 msgid "Your opinion is appreciated"
 msgstr "Ваше мнение очень важно для нас"
 
-#: .\templates\django_comments_xtd\moderated.html:4
+#: templates/django_comments_xtd/moderated.html:4
 msgid "Comment requires approval"
 msgstr "Комментарий требует подтверждения"
 
-#: .\templates\django_comments_xtd\moderated.html:8
+#: templates/django_comments_xtd/moderated.html:8
 msgid "Comment in moderation"
 msgstr "Комментарий на модерации"
 
-#: .\templates\django_comments_xtd\moderated.html:14
+#: templates/django_comments_xtd/moderated.html:14
 msgid ""
 "\n"
 "            Your comment is in moderation.<br/>\n"
@@ -327,44 +428,78 @@ msgstr ""
 "Он должен быть отсмотрен перед публикацией.<br/>\n"
 "Спасибо за терпение и понимание."
 
-#: .\templates\django_comments_xtd\moderated.html:22
+#: templates/django_comments_xtd/moderated.html:22
 #, python-format
 msgid ""
 "\n"
-"            Go back to: <a href=\"%(content_object_url)s\">%(content_object_str)s</a>\n"
+"            Go back to: <a href=\"%(content_object_url)s\">"
+"%(content_object_str)s</a>\n"
 "            "
 msgstr ""
 "\n"
-"Вернуться обратно к: <a href=\"%(content_object_url)s\">%(content_object_str)s</a>"
+"Вернуться обратно к: <a href=\"%(content_object_url)s\">"
+"%(content_object_str)s</a>"
 
-#: .\templates\django_comments_xtd\muted.html:4
-#, fuzzy
+#: templates/django_comments_xtd/muted.html:4
 msgid "Comment thread muted"
 msgstr ""
 
-#: .\templates\django_comments_xtd\muted.html:7
-#, fuzzy
+#: templates/django_comments_xtd/muted.html:7
 msgid "Comment thread has been muted"
 msgstr ""
 
-#: .\templates\django_comments_xtd\muted.html:9
+#: templates/django_comments_xtd/muted.html:9
 msgid "You will no longer receive email notifications for comments sent to"
 msgstr ""
 "Вы больше не будете получать уведомления на почту о комментариях, "
 "отправленных к:"
 
-#: .\templates\django_comments_xtd\reply.html:6
+#: templates/django_comments_xtd/only_users_can_post.html:5
+msgid "Only registered users can post comments."
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:1
+msgid "A removal suggestion has been received for the following comment:"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:7
+msgid "Posted to the following URL"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:10
+msgid "Removal suggested by"
+msgstr ""
+
+#: templates/django_comments_xtd/reply.html:6
 msgid "Comment reply"
 msgstr "Ответ на комментарий"
 
-#: .\templates\django_comments_xtd\reply.html:11
+#: templates/django_comments_xtd/reply.html:11
 msgid "Reply to comment"
 msgstr "Ответить на комментарий"
 
-#: .\views.py:49
+#: tests/apiauth.py:17
+msgid "Invalid token header. No credentials provided."
+msgstr ""
+
+#: tests/apiauth.py:20
+msgid "Invalid token header.Token string should not contain spaces."
+msgstr ""
+
+#: tests/apiauth.py:27
+msgid ""
+"Invalid token header. Token string should not contain invalid characters."
+msgstr ""
+
+#: views.py:60
 msgid "comment confirmation request"
 msgstr "запрос на подтверждение комментария"
 
-#: .\views.py:212
+#: views.py:278
 msgid "new comment posted"
 msgstr "опубликован новый комментарий"
+
+#, fuzzy
+#~| msgid "Kind regards"
+#~ msgid "Kind regards,"
+#~ msgstr "С уважением"

--- a/django_comments_xtd/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/django_comments_xtd/locale/zh_Hans/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-28 15:38+0800\n"
+"POT-Creation-Date: 2022-09-17 23:38+0200\n"
 "PO-Revision-Date: 2021-09-29 15:10+0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -64,6 +64,35 @@ msgstr "你的评论"
 msgid "Notify follow-up comments"
 msgstr "通知后续评论"
 
+#: templates/404.html:9
+msgid "Page not found"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:1
+msgid "A new comment has been sent to the following URL:"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:5
+#: templates/django_comments_xtd/email_followup_comment.html:5
+#: templates/django_comments_xtd/email_followup_comment.txt:8
+msgid "Sent by"
+msgstr ""
+
+#: templates/comments/comment_notification_email.txt:6
+#, fuzzy
+#| msgid "mail address"
+msgid "Email address"
+msgstr "邮件地址"
+
+#: templates/comments/comment_notification_email.txt:8
+#: templates/django_comments_xtd/email_confirmation_request.txt:7
+#: templates/django_comments_xtd/email_followup_comment.txt:10
+#: templates/django_comments_xtd/removal_notification_email.txt:3
+#, fuzzy
+#| msgid "Comment reply"
+msgid "Comment"
+msgstr "评论回复"
+
 #: templates/comments/delete.html:5
 msgid "Remove comment"
 msgstr "删除评论"
@@ -77,11 +106,19 @@ msgid ""
 "As a moderator you can delete comments. Deleting a comment does not remove "
 "it from the site, only prevents your website from showing the text. Click on "
 "the remove button to delete the following comment:"
-msgstr "作为版主，你可以删除评论。删除评论不会将其从网站上删除，只会阻止你的网站显示其文本。点击删除按钮删除以下评论："
+msgstr ""
+"作为版主，你可以删除评论。删除评论不会将其从网站上删除，只会阻止你的网站显示"
+"其文本。点击删除按钮删除以下评论："
 
 #: templates/comments/delete.html:45
 msgid "Remove"
 msgstr "删除"
+
+#: templates/comments/delete.html:46 templates/comments/flag.html:57
+#: templates/django_comments_xtd/dislike.html:74
+#: templates/django_comments_xtd/like.html:73
+msgid "cancel"
+msgstr "取消"
 
 #: templates/comments/deleted.html:5
 msgid "Comment removed"
@@ -121,12 +158,6 @@ msgstr "发布到 "
 msgid "Flag"
 msgstr "标记"
 
-#: templates/comments/flag.html:57
-#: templates/django_comments_xtd/dislike.html:74
-#: templates/django_comments_xtd/like.html:73
-msgid "cancel"
-msgstr "取消"
-
 #: templates/comments/flagged.html:5
 msgid "Comment flagged"
 msgstr "评论已标记"
@@ -162,6 +193,10 @@ msgstr ""
 "确认消息已发送至你的电子邮件地址。\n"
 "请点击邮件中的链接确认你的评论。"
 
+#: templates/comments/posted.html:17
+msgid "Go back to"
+msgstr ""
+
 #: templates/comments/preview.html:5 templates/comments/preview.html:10
 msgid "Preview your comment"
 msgstr "预览你的评论"
@@ -182,6 +217,12 @@ msgstr "发表你的评论"
 #: templates/django_comments_xtd/comment_list.html:11
 msgid "List of comments"
 msgstr "评论列表"
+
+#: templates/django_comments_xtd/comment_list.html:21
+#, fuzzy
+#| msgid "Your comment"
+msgid "No comments yet."
+msgstr "你的评论"
 
 #: templates/django_comments_xtd/comment_tree.html:12
 msgid "moderator"
@@ -264,13 +305,72 @@ msgstr "你不喜欢这个评论"
 msgid "Thanks for taking the time to participate."
 msgstr "感谢你抽出时间参加。"
 
+#: templates/django_comments_xtd/email_confirmation_request.html:3
+#: templates/django_comments_xtd/email_confirmation_request.txt:3
+msgid ""
+"You or someone in behalf of you have requested to post a comment into this "
+"page:"
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:7
+#: templates/django_comments_xtd/email_followup_comment.html:8
+#, fuzzy
+#| msgid "Remove comment"
+msgid "The comment"
+msgstr "删除评论"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:11
+#: templates/django_comments_xtd/email_confirmation_request.txt:11
+#, python-format
+msgid ""
+"If you do not wish to post the comment, please ignore this message or report "
+"an incident to %(contact)s. Otherwise click on the link below to confirm the "
+"comment."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:15
+#: templates/django_comments_xtd/email_confirmation_request.txt:15
+msgid ""
+"If clicking does not work, you can also copy and paste the address into your "
+"browser's address window."
+msgstr ""
+
+#: templates/django_comments_xtd/email_confirmation_request.html:17
+#: templates/django_comments_xtd/email_confirmation_request.txt:16
+#, fuzzy
+#| msgid "Post your comment"
+msgid "Thanks for your comment!"
+msgstr "发表你的评论"
+
+#: templates/django_comments_xtd/email_confirmation_request.html:19
+#: templates/django_comments_xtd/email_confirmation_request.txt:19
+#: templates/django_comments_xtd/email_followup_comment.html:14
+#: templates/django_comments_xtd/email_followup_comment.txt:20
+msgid "Kind regards"
+msgstr "亲切问候"
+
+#: templates/django_comments_xtd/email_followup_comment.html:3
 #: templates/django_comments_xtd/email_followup_comment.txt:4
 msgid "There is a new comment following up yours."
 msgstr "有一条新评论跟在你的评论后面。"
 
-#: templates/django_comments_xtd/email_followup_comment.txt:20
-msgid "Kind regards"
-msgstr "亲切问候"
+#: templates/django_comments_xtd/email_followup_comment.html:12
+#, python-format
+msgid ""
+"Click <a href=\"http://%(site_domain)s%(mute_url)s\">http://%(site_domain)s"
+"%(mute_url_short)s...</a> to mute the comments thread. You will no longer "
+"receive follow-up notifications."
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:6
+msgid "Post"
+msgstr ""
+
+#: templates/django_comments_xtd/email_followup_comment.txt:15
+msgid ""
+"Click on the following link to mute the comments thread. You will no longer "
+"receive follow-up notifications:"
+msgstr ""
 
 #: templates/django_comments_xtd/like.html:15
 msgid "You liked this comment, do you want to change it?"
@@ -339,6 +439,22 @@ msgstr "评论跟帖已静音"
 msgid "You will no longer receive email notifications for comments sent to"
 msgstr "你将不再收到发送给评论的电子邮件通知"
 
+#: templates/django_comments_xtd/only_users_can_post.html:5
+msgid "Only registered users can post comments."
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:1
+msgid "A removal suggestion has been received for the following comment:"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:7
+msgid "Posted to the following URL"
+msgstr ""
+
+#: templates/django_comments_xtd/removal_notification_email.txt:10
+msgid "Removal suggested by"
+msgstr ""
+
 #: templates/django_comments_xtd/reply.html:6
 msgid "Comment reply"
 msgstr "评论回复"
@@ -367,3 +483,8 @@ msgstr "评论确认请求"
 #: views.py:278
 msgid "new comment posted"
 msgstr "发布了新评论"
+
+#, fuzzy
+#~| msgid "Kind regards"
+#~ msgid "Kind regards,"
+#~ msgstr "亲切问候"

--- a/django_comments_xtd/templates/404.html
+++ b/django_comments_xtd/templates/404.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
 <head>
@@ -5,6 +6,6 @@
   <title>{% block title %}django-comments-xtd&nbsp;&raquo;&nbsp;code 404{% endblock %}</title>
 </head>
 <body>
-  <h3>Page not found</h3>
+  <h3>{% trans 'Page not found' %}</h3>
 </body>
 </html>

--- a/django_comments_xtd/templates/comments/comment_notification_email.txt
+++ b/django_comments_xtd/templates/comments/comment_notification_email.txt
@@ -1,9 +1,9 @@
-A new comment has been sent to the following URL:
+{% load i18n %}{% trans 'A new comment has been sent to the following URL:' %}
 
 {{ content_object.get_absolute_url }}
 
-Submitted by: {{ comment.user_name }}
-Email address: {{ comment.user_email }}
+{% trans 'Sent by' %}: {{ comment.user_name }}
+{% trans 'Email address' %}: {{ comment.user_email }}
 
---- Comment: ---
+--- {% trans 'Comment' %}: ---
 {{ comment.comment }}

--- a/django_comments_xtd/templates/comments/delete.html
+++ b/django_comments_xtd/templates/comments/delete.html
@@ -43,7 +43,7 @@
         <div class="form-group">
           <div class="text-center">
             <input type="submit" name="submit" class="btn btn-danger" value="{% trans "Remove" %}"/>
-            <a class="btn btn-secondary" href="{{ comment.get_absolute_url }}">cancel</a>
+            <a class="btn btn-secondary" href="{{ comment.get_absolute_url }}">{% trans 'cancel' %}</a>
           </div>
         </div>
     </form>

--- a/django_comments_xtd/templates/comments/posted.html
+++ b/django_comments_xtd/templates/comments/posted.html
@@ -14,7 +14,7 @@
             your comment.{% endblocktrans %}
         </p>
         <p class="pt-5 text-center">
-            Go back to: <a href="{{ target.get_absolute_url }}">{{ target }}</a>
+            {% trans 'Go back to' %}: <a href="{{ target.get_absolute_url }}">{{ target }}</a>
         </p>
     </div>
 </div>

--- a/django_comments_xtd/templates/django_comments_xtd/comment_list.html
+++ b/django_comments_xtd/templates/django_comments_xtd/comment_list.html
@@ -18,7 +18,7 @@
                     {% for comment in object_list %}
                     {% include "django_comments_xtd/comment.html" %}
                     {% empty %}
-                    <p class="text-center">No comments yet.</p>
+                    <p class="text-center">{% trans 'No comments yet.' %}</p>
                     {% endfor %}
                 </div>
 

--- a/django_comments_xtd/templates/django_comments_xtd/email_confirmation_request.html
+++ b/django_comments_xtd/templates/django_comments_xtd/email_confirmation_request.html
@@ -1,20 +1,20 @@
-<p>{{ comment.user_name }},</p>
+{% load i18n %}<p>{{ comment.user_name }},</p>
 
-<p>You or someone in behalf of you have requested to post a comment into this page:<br/>
+<p>{% trans 'You or someone in behalf of you have requested to post a comment into this page:' %}<br/>
 <a href="http://{{ site.domain }}{{ comment.content_object.get_absolute_url }}">http://{{ site.domain }}{{ comment.content_object.get_absolute_url }}</a>
 </p>
 
-<p>The comment:<br/>
+<p>{% trans 'The comment' %}:<br/>
 <i>{{ comment.comment }}</i>
 <hr/>
 
-<p>If you do not wish to post the comment, please ignore this message or report an incident to {{ contact }}. Otherwise click on the link below to confirm the comment.</p>
+<p>{% blocktrans %}If you do not wish to post the comment, please ignore this message or report an incident to {{ contact }}. Otherwise click on the link below to confirm the comment.{% endblocktrans %}</p>
 
 <p><a href="http://{{ site.domain }}{{ confirmation_url }}">http://{{ site.domain }}{{ confirmation_url|slice:":40" }}...</a></p>
 
-<p>If clicking does not work, you can also copy and paste the address into your browser's address window.</p>
+<p>{% trans "If clicking does not work, you can also copy and paste the address into your browser's address window." %}</p>
 
-<p>Thanks for your comment!<br/>
+<p>{% trans 'Thanks for your comment!' %}<br/>
 --<br/>
-Kind regards,<br/>
+{% trans 'Kind regards' %},<br/>
 {{ site }}</p>

--- a/django_comments_xtd/templates/django_comments_xtd/email_confirmation_request.txt
+++ b/django_comments_xtd/templates/django_comments_xtd/email_confirmation_request.txt
@@ -1,20 +1,20 @@
-{{ comment.user_name }},
+{% load i18n %}{{ comment.user_name }},
 
-You or someone in behalf of you have requested to post a comment to the following URL.
+{% trans 'You or someone in behalf of you have requested to post a comment into this page:' %}
 
 URL:  http://{{ site.domain }}{{ comment.content_object.get_absolute_url }}
 
---- Comment: ---
+--- {% trans 'Comment' %}': ---
 {{ comment.comment }}
 ----------------
 
-If you do not wish to post the comment, please ignore this message or report an incident to {{ contact|safe }}. Otherwise click on the link below to confirm the comment.
+{% blocktrans with contact=contact|safe %}If you do not wish to post the comment, please ignore this message or report an incident to {{ contact }}. Otherwise click on the link below to confirm the comment.{% endblocktrans %}
 
 http://{{ site.domain }}{{ confirmation_url }}
 
-If clicking does not work, you can also copy and paste the address into your browser's address window.
-Thanks for your comment!
+{% trans "If clicking does not work, you can also copy and paste the address into your browser's address window." %}
+{% trans 'Thanks for your comment!' %}
 
 --
-Kind regards,
+{% trans 'Kind regards' %},
 {{ site }}

--- a/django_comments_xtd/templates/django_comments_xtd/email_followup_comment.html
+++ b/django_comments_xtd/templates/django_comments_xtd/email_followup_comment.html
@@ -1,16 +1,16 @@
-<p>{{ user_name }},</p>
+{% load i18n %}<p>{{ user_name }},</p>
 
-<p>There is a new comment following up yours.</p>
+<p>{% trans 'There is a new comment following up yours.' %}</p>
 
-<p>Sent by: {{ comment.name }}, {{ comment.submit_date|date:"SHORT_DATE_FORMAT" }}<br/>
+<p>{% trans 'Sent by' %}: {{ comment.name }}, {{ comment.submit_date|date:"SHORT_DATE_FORMAT" }}<br/>
 <a href="http://{{ site.domain }}{{ comment.content_object.get_absolute_url }}">http://{{ site.domain }}{{ comment.content_object.get_absolute_url }}</a></p>
 
-<p>The comment:<br/>
+<p>{% trans 'The comment' %}:<br/>
 <i>{{ comment.comment }}</i>
 </p>
 
-<p>Click <a href="http://{{ site.domain }}{{ mute_url }}">http://{{ site.domain }}{{ mute_url|slice:":40" }}...</a> to mute the comments thread. You will no longer receive follow-up notifications.</p>
+<p>{% blocktrans with site_domain=site.domain mute_url_short=mute_url|slice:":40" %}Click <a href="http://{{ site_domain }}{{ mute_url }}">http://{{ site_domain }}{{ mute_url_short }}...</a> to mute the comments thread. You will no longer receive follow-up notifications.{% endblocktrans %}</p>
 <p>--<br/>
-Kind regards,<br/>
+{% trans 'Kind regards' %},<br/>
 {{ site }}
 </p>

--- a/django_comments_xtd/templates/django_comments_xtd/email_followup_comment.txt
+++ b/django_comments_xtd/templates/django_comments_xtd/email_followup_comment.txt
@@ -3,16 +3,16 @@
 
 {% blocktrans %}There is a new comment following up yours.{% endblocktrans %}
 
-Post: {{ content_object.title }}
+{% trans 'Post' %}': {{ content_object.title }}
 URL:  http://{{ site.domain }}{{ content_object.get_absolute_url }}
-Sent by: {{ comment.name }}, {{ comment.submit_date|date:"SHORT_DATE_FORMAT" }}
+{% trans 'Sent by' %}': {{ comment.name }}, {{ comment.submit_date|date:"SHORT_DATE_FORMAT" }}
 
---- Comment: ---
+--- {% trans 'Comment' %}': ---
 {{ comment.comment }}
 
 
 -----
-Click on the following link to mute the comments thread. You will no longer receive follow-up notifications:
+{% trans 'Click on the following link to mute the comments thread. You will no longer receive follow-up notifications:' %}
 
 http://{{ site.domain }}{{ mute_url }}
 

--- a/django_comments_xtd/templates/django_comments_xtd/only_users_can_post.html
+++ b/django_comments_xtd/templates/django_comments_xtd/only_users_can_post.html
@@ -1,5 +1,7 @@
+{% load i18n %}
+
 <div id="only-users-can-post-{{ html_id_suffix }}">
   <p class="mt-4 mb-5 text-center text-info">
-  	Only registered users can post comments.
+  	{% trans 'Only registered users can post comments.' %}
   </p>
 </div>

--- a/django_comments_xtd/templates/django_comments_xtd/removal_notification_email.txt
+++ b/django_comments_xtd/templates/django_comments_xtd/removal_notification_email.txt
@@ -1,10 +1,10 @@
-A removal suggestion has been received for the following comment:
+{% load i18n %}{% trans 'A removal suggestion has been received for the following comment:' %}
 
---- Comment: ---
+--- {% trans 'Comment' %}': ---
 {{ comment.comment }}
 
 
-Posted to the following URL:
+{% trans 'Posted to the following URL' %}':
 http{% if request.is_secure %}s{% endif %}://{{ current_site.domain }}{{ content_object.get_absolute_url }}
 
-Removal suggested by: {{ request.user }}
+{% trans 'Removal suggested by' %}': {{ request.user }}


### PR DESCRIPTION
Many translation calls are missing in the provided templates.