### PR TITLE
WriteCommentSerializer: local variable 'model' referenced before assignment

### DIFF
--- a/django_comments_xtd/api/serializers.py
+++ b/django_comments_xtd/api/serializers.py
@@ -91,14 +91,14 @@ class WriteCommentSerializer(serializers.Serializer):
             model = apps.get_model(*ctype.split(".", 1))
             target = model._default_manager.get(pk=object_pk)
             whocan = get_app_model_options(content_type=ctype)['who_can_post']
-        except (AttributeError, TypeError, LookupError):
+        except (AttributeError, TypeError, LookupError, ValueError):
             raise serializers.ValidationError("Invalid content_type value: %r"
                                               % escape(ctype))
         except model.DoesNotExist:
             raise serializers.ValidationError(
                 "No object matching content-type %r and object PK %r exists."
                 % (escape(ctype), escape(object_pk)))
-        except (ValueError, serializers.ValidationError) as e:
+        except (serializers.ValidationError) as e:
             raise serializers.ValidationError(
                 "Attempting to get content-type %r and object PK %r exists "
                 "raised %s" % (escape(ctype), escape(object_pk),


### PR DESCRIPTION
Error happens [here](https://github.com/danirus/django-comments-xtd/blob/master/django_comments_xtd/api/serializers.py#L97). It happens when `apps.get_model(*ctype.split(".", 1))` returns exception other than `AttributeError, TypeError, LookupError`. For example if `ctype="bla"` `*ctype.split(".", 1)` raises `ValueError`. I think in this case makes sense to handle `ValueError` earlier.  