### PR TITLE
WriteCommentSerializer: enable to override get_form() function

### DIFF
--- a/django_comments_xtd/api/serializers.py
+++ b/django_comments_xtd/api/serializers.py
@@ -85,6 +85,9 @@ class WriteCommentSerializer(serializers.Serializer):
                         "Max thread level reached")
         return value
 
+    def get_form(self):
+        return get_form()
+
     def validate(self, data):
         ctype = data.get("content_type")
         object_pk = data.get("object_pk")
@@ -130,7 +133,7 @@ class WriteCommentSerializer(serializers.Serializer):
                     "security_hash": secform['security_hash'].value()
                 })
                 break
-        self.form = get_form()(target, data=data)
+        self.form = self.get_form()(target, data=data)
 
         # Check security information.
         if self.form.security_errors():


### PR DESCRIPTION
Enable overriding `get_form()` function in `WriteCommentSerializer` to allow easier change of the form class.