### PR TITLE
Fix code-blocks in the docs

### DIFF
--- a/docs/example.rst
+++ b/docs/example.rst
@@ -42,32 +42,37 @@ Setup
 =====
 
 The recommended way to run a demo site is within its own `virtualenv
-<http://www.virtualenv.org/en/latest/>`_. Once in a new virtualenv, clone the
+<http://www.virtualenv.org/en/latest/>`_:
+
+.. code-block:: bash
+
+    virtualenv venv
+    source venv/bin/activate
+
+Once in a new virtualenv, clone the
 code and cd into any of the 3 demo sites. Then run the migrate command and
 load the data in the fixtures directory:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-    $ virtualenv venv
-    $ source venv/bin/activate
-    (venv)$ git clone git://github.com/danirus/django-comments-xtd.git
-    (venv)$ cd django-comments-xtd/
-    (venv)$ python setup.py install
-    (venv)$ npm install
-    (venv)$ node_modules/webpack/bin/webpack.js -p
-    (venv)$ cd django_comments_xtd
-    (venv)$ django-admin compilemessages -l fi
-    (venv)$ django-admin compilemessages -l fr
-    (venv)$ django-admin compilemessages -l es
-    (venv)$ cd ../example/[simple|custom|comp]
-    (venv)$ pip install -r requirements.txt
-    (venv)$ python manage.py migrate
-    (venv)$ python manage.py loaddata ../fixtures/auth.json
-    (venv)$ python manage.py loaddata ../fixtures/sites.json
-    (venv)$ python manage.py loaddata ../fixtures/articles.json
-    (venv)$ # The **comp** example project needs quotes.json too:
-    (venv)$ python manage.py loaddata ../fixtures/quotes.json
-    (venv)$ python manage.py runserver
+    git clone git://github.com/danirus/django-comments-xtd.git
+    cd django-comments-xtd/
+    python setup.py install
+    npm install
+    node_modules/webpack/bin/webpack.js -p
+    cd django_comments_xtd
+    django-admin compilemessages -l fi
+    django-admin compilemessages -l fr
+    django-admin compilemessages -l es
+    cd ../example/[simple|custom|comp]
+    pip install -r requirements.txt
+    python manage.py migrate
+    python manage.py loaddata ../fixtures/auth.json
+    python manage.py loaddata ../fixtures/sites.json
+    python manage.py loaddata ../fixtures/articles.json
+    # The **comp** example project needs quotes.json too:
+    python manage.py loaddata ../fixtures/quotes.json
+    python manage.py runserver
 
 Example projects make use of the package `django-markdown2
 <https://github.com/svetlyak40wt/django-markdown2>`_, which in turn depends on

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -23,42 +23,49 @@ Contributions
 
 This is a step by step guide to help extending the internationalization of django-comments-xtd. Install the **comp** example site. It will be used along with `django-rosetta <https://github.com/mbi/django-rosetta>`_ to help with translations.
 
-   .. code-block:: bash
+First create and enable a virtual environment:
 
-    $ virtualenv venv
-    $ source venv/bin/activate
-    (venv)$ git clone git://github.com/danirus/django-comments-xtd.git
-    (venv)$ cd django-comments-xtd/example/comp
-    (venv)$ pip install django-rosetta django-markdown2
-    (venv)$ python manage.py migrate
-    (venv)$ python manage.py loaddata ../fixtures/auth.json
-    (venv)$ python manage.py loaddata ../fixtures/sites.json
-    (venv)$ python manage.py loaddata ../fixtures/articles.json
-    (venv)$ python manage.py loaddata ../fixtures/quotes.json
-    (venv)$ python manage.py runserver
+.. code-block:: bash
+
+    virtualenv venv
+    source venv/bin/activate
+
+And then prepare the comp example project:
+
+.. code-block:: bash
+
+    git clone git://github.com/danirus/django-comments-xtd.git
+    cd django-comments-xtd/example/comp
+    pip install django-rosetta django-markdown2
+    python manage.py migrate
+    python manage.py loaddata ../fixtures/auth.json
+    python manage.py loaddata ../fixtures/sites.json
+    python manage.py loaddata ../fixtures/articles.json
+    python manage.py loaddata ../fixtures/quotes.json
+    python manage.py runserver
 
 Edit the **comp/settings.py** module. Add the `ISO-639-1 <https://en.wikipedia.org/wiki/ISO_639-1>`_ code of the language you want to support to :setting:`LANGUAGES` and add ``'rosetta'`` to your :setting:`INSTALLED_APPS`.
 
-   .. code-block:: python
+.. code-block:: python
 
-       LANGUAGES = (
-           ('nl', 'Dutch'),
-           ('en', 'English'),
-           ('fi', 'Finnish'),
-           ('fr', 'French'),
-           ('de', 'German'),
-           ('no', 'Norwegian'),
-           ('ru', 'Russian'),
-           ('es', 'Spanish'),
-           ('it', 'Italian'),
-           ...
-       )
+    LANGUAGES = (
+        ('nl', 'Dutch'),
+        ('en', 'English'),
+        ('fi', 'Finnish'),
+        ('fr', 'French'),
+        ('de', 'German'),
+        ('no', 'Norwegian'),
+        ('ru', 'Russian'),
+        ('es', 'Spanish'),
+        ('it', 'Italian'),
+        ...
+    )
 
-       INSTALLED_APPS = [
-           ...
-           'rosetta',
-           ...
-       ]
+    INSTALLED_APPS = [
+        ...
+        'rosetta',
+        ...
+    ]
 
 .. note::
 
@@ -68,21 +75,26 @@ We have to create the translation catalog for the new language. Use the `ISO-639
 
 The frontend catalog is produced out of the **plugin-X.Y.Z.js** file. It's a good idea to run the ``webpack --watch`` command if you change the messages in the sources of the plugin (placed in the **js/src/** directory). This way the plugin is built automatically and the Django ``makemessages`` command will fetch the new messages accordingly.
 
-Keep the runserver command launched above running in one terminal and open another terminal to run the **makemessages** and **compilemessages** commands:
+Keep the runserver command launched above running in one terminal and open another terminal to run the **makemessages** and **compilemessages** commands. First enable the virtual environment:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-    $ source venv/bin/activate
-    (venv)$ cd django-comments-xtd/django_comments_xtd
-    (venv)$ django-admin makemessages -l de
-    (venv)$ django-admin makemessages -d djangojs -l de
+    source venv/bin/activate
+
+And then run the commands:
+
+.. code-block:: bash
+
+    cd django-comments-xtd/django_comments_xtd
+    django-admin makemessages -l de
+    django-admin makemessages -d djangojs -l de
 
 Now head to the rosetta page, under http://localhost:8000/rosetta/, do login with user ``admin`` and password ``admin``, and proceed to translate the messages. Find the two catalogs for django-comments-xtd under the **Third Party** filter, at the top-right side of the page.
 
 Django must have the catalogs compiled before the messages show up in the comp site. Run the compile message for that purpose:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-    (venv)$ django-admin compilemessages
+    django-admin compilemessages
 
 The **comp** example site is now ready to show the messages in the new language. It's time to verify that the translation fits the UI. If everything looks good, please, make a Pull Request to add the new .po files to the upstream repository.

--- a/docs/javascript.rst
+++ b/docs/javascript.rst
@@ -38,36 +38,36 @@ Before installing the frontend dependencies we will prepare a Python virtualenv
 in which we will have all the backend dependencies installed. Let's start by
 creating the virtualenv and fetching the sources:
 
-   .. code-block:: shell
+.. code-block:: shell
 
-       $ virtualenv ~/venv/django-comments-xtd
-       $ source ~/venv/django-comments-xtd/bin/activate
-       $ cd ~/src/  # or cd into your sources dir of choice.
-       $ git clone https://github.com/danirus/django-comments-xtd.git
-       $ cd django-comments-xtd
-       $ pip install -e .
+    virtualenv ~/venv/django-comments-xtd
+    source ~/venv/django-comments-xtd/bin/activate
+    cd ~/src/  # or cd into your sources dir of choice.
+    git clone https://github.com/danirus/django-comments-xtd.git
+    cd django-comments-xtd
+    pip install -e .
 
 Check whether the app passes the battery of tests:
 
-   .. code-block:: shell
+.. code-block:: shell
 
-       $ pytest -x
+    python -m pytest -x
 
 As the sample Django project you can use the **comp** example site. Install
 first the django-markdown2 package (required by the comp example project) and
 setup the project:
 
-   .. code-block:: shell
+.. code-block:: shell
 
-       $ cd example/comp
-       $ pip install django-markdown2
-       $ pip install django-rosetta
-       $ python manage.py migrate
-       $ python manage.py loaddata ../fixtures/auth.json
-       $ python manage.py loaddata ../fixtures/sites.json
-       $ python manage.py loaddata ../fixtures/articles.json
-       $ python manage.py loaddata ../fixtures/quotes.json
-       $ python manage.py runserver
+    cd example/comp
+    pip install django-markdown2
+    pip install django-rosetta
+    python manage.py migrate
+    python manage.py loaddata ../fixtures/auth.json
+    python manage.py loaddata ../fixtures/sites.json
+    python manage.py loaddata ../fixtures/articles.json
+    python manage.py loaddata ../fixtures/quotes.json
+    python manage.py runserver
 
 Now the project is ready and the plugin will load from the existing bundle
 files. Check it out by visiting an article's page and sending some comments. No
@@ -80,71 +80,75 @@ Install frontend packages
 At this point open another terminal and cd into django-comments-xtd source
 directory again, then install all the frontend dependencies:
 
-   .. code-block:: shell
+.. code-block:: shell
 
-       $ cd ~/src/django-comments-xtd
-       $ npm install
+    cd ~/src/django-comments-xtd
+    npm install
 
 It will install all the dependencies listed in the **package.json** file in the
 local `node_modules` directory. Once it's finished run webpack to build the
 bundles and watch for changes in the source tree:
 
-   .. code-block:: shell
+.. code-block:: shell
 
-       $ npm run compile
+       npm run compile
 
 Rollup puts the bundle in the static directory of django-comments-xtd and
 Django will fetch it from there when rendering the article's detail page:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% block extra-js %}
-       [...]
-       <script src="{% static 'django_comments_xtd/js/django-comments-xtd-2.9.13.js' %}"></script>
-       {% endblock extra-js %}
+    {% block extra-js %}
+    [...]
+    <script src="{% static 'django_comments_xtd/js/django-comments-xtd-2.9.13.js' %}"></script>
+    {% endblock extra-js %}
 
 Code structure
 ==============
 
 Plugin sources live inside the **static** directory of django-comments-xtd:
 
-   .. code-block:: shell
+.. code-block:: shell
 
-       $ cd ~/src/django-comments-xtd
-       $ tree django_comments_xtd/static/django_comments_xtd/js
+    cd ~/src/django-comments-xtd
+    tree django_comments_xtd/static/django_comments_xtd/js
 
-       django_comments_xtd/static/django_comments_xtd/js
-       ├── src
-       │   ├── app.js
-       │   ├── comment.jsx
-       │   ├── commentbox.jsx
-       │   ├── commentform.jsx
-       │   ├── index.js
-       │   └── lib.js
-       ├── tests
-       │   ├── comment.test.jsx
-       │   ├── commentform.test.jsx
-       │   ├── reducer.test.jsx
-       │   └── lib.test.js
-       ├── django-comments-xtd-2.9.12.js
-       └── django-comments-xtd-2.9.12.min.js
+Which results in:
+
+.. code-block::
+
+    django_comments_xtd/static/django_comments_xtd/js
+    ├── src
+    │   ├── app.js
+    │   ├── comment.jsx
+    │   ├── commentbox.jsx
+    │   ├── commentform.jsx
+    │   ├── index.js
+    │   └── lib.js
+    ├── tests
+    │   ├── comment.test.jsx
+    │   ├── commentform.test.jsx
+    │   ├── reducer.test.jsx
+    │   └── lib.test.js
+    ├── django-comments-xtd-2.9.12.js
+    └── django-comments-xtd-2.9.12.min.js
 
 The application entry point is located inside the ``index.js`` file. The
 ``props`` passed to the **CommentBox** object are those declared in the
 ``var window.comments_props`` defined in the django template:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       <script>
-         window.comments_props = {% get_commentbox_props for object %};
-         window.comments_props_override = {
-           allow_comments: {%if object.allow_comments%}true{%else%}false{%endif%},
-           allow_feedback: true,
-           show_feedback: true,
-           allow_flagging: true,
-           polling_interval: 2000,
-         };
-       </script>
+    <script>
+      window.comments_props = {% get_commentbox_props for object %};
+      window.comments_props_override = {
+        allow_comments: {%if object.allow_comments%}true{%else%}false{%endif%},
+        allow_feedback: true,
+        show_feedback: true,
+        allow_flagging: true,
+        polling_interval: 2000,
+      };
+    </script>
 
 And are overriden by those declared in the
 ``window.comments_props_override``.

--- a/docs/logic.rst
+++ b/docs/logic.rst
@@ -7,7 +7,7 @@ Control logic
 Following is the application control logic described in 4 actions:
 
 1. The user visits a page that accepts comments. Your app or a 3rd. party app handles the request:
- 
+
  a. Your template shows content that accepts comments. It loads the ``comments`` templatetag and using tags as ``render_comment_list`` and ``render_comment_form`` the template shows the current list of comments and the *post your comment* form.
 
 2. The user **clicks on preview**. Django Comments Framework ``post_comment`` view handles the request:
@@ -16,7 +16,7 @@ Following is the application control logic described in 4 actions:
 
 3. The user **clicks on post**. Django Comments Framework ``post_comment`` view handles the request:
 
- a. If there were form errors it does the same as in point 2. 
+ a. If there were form errors it does the same as in point 2.
 
  b. Otherwise creates an instance of ``TmpXtdComment`` model: an in-memory representation of the comment.
 
@@ -39,7 +39,7 @@ Following is the application control logic described in 4 actions:
 4. The user **clicks on the confirmation link**, in the email message. *Django-comments-xtd* ``confirm`` view handles the request:
 
  a. Checks the secured token in the URL. If it's wrong returns a 404 code.
- 
+
  b. Otherwise checks whether the comment was already confirmed, in such a case returns a 404 code.
 
  c. Otherwise sends a ``confirmation_received`` signal. You can register a receiver to this signal to do some extra process before approving the comment. See :ref:`signal-and-receiver-label`. If any receiver returns False the comment will be rejected and the template ``django_comments_xtd/discarded.html`` will be rendered.
@@ -50,12 +50,12 @@ Following is the application control logic described in 4 actions:
 
 
 .. _the-secure-token-label:
-     
+
 
 Creating the secure token for the confirmation URL
 ==================================================
 
-The Confirmation URL sent by email to the user has a secured token with the comment. To create the token Django-comments-xtd uses the module ``signed.py`` authored by Simon Willison and provided in `Django-OpenID <http://github.com/simonw/django-openid>`_. 
+The Confirmation URL sent by email to the user has a secured token with the comment. To create the token Django-comments-xtd uses the module ``signed.py`` authored by Simon Willison and provided in `Django-OpenID <http://github.com/simonw/django-openid>`_.
 
 ``django_openid.signed`` offers two high level functions:
 
@@ -112,36 +112,36 @@ You might want to register a receiver for ``confirmation_received``. An example 
 
 Extending the demo site with the following code will do the job:
 
-   .. code-block:: python
-  
-       #----------------------------------------
-       # append the below code to demos/simple/views.py:
+.. code-block:: python
 
-       from datetime import datetime, timedelta
-       from django_comments_xtd import signals
+    #----------------------------------------
+    # append the below code to demos/simple/views.py:
 
-       def check_submit_date_is_within_last_7days(sender, data, request, **kwargs):
-           plus7days = timedelta(days=7)
-	       if data["submit_date"] + plus7days < datetime.now():
-	           return False
+    from datetime import datetime, timedelta
+    from django_comments_xtd import signals
 
-       signals.confirmation_received.connect(check_submit_date_is_within_last_7days)
-    
-    
-       #-----------------------------------------------------
-       # change get_comment_create_data in django_comments_xtd/forms.py to cheat a
-       # bit and make Django believe that the comment was submitted 7 days ago:
+    def check_submit_date_is_within_last_7days(sender, data, request, **kwargs):
+        plus7days = timedelta(days=7)
+      if data["submit_date"] + plus7days < datetime.now():
+          return False
 
-       def get_comment_create_data(self):
-	       from datetime import timedelta                                     # ADD THIS
+    signals.confirmation_received.connect(check_submit_date_is_within_last_7days)
 
-           data = super(CommentForm, self).get_comment_create_data()
-           data['followup'] = self.cleaned_data['followup']
-           if settings.COMMENTS_XTD_CONFIRM_EMAIL:
-               # comment must be verified before getting approved
-               data['is_public'] = False
-               data['submit_date'] = datetime.datetime.now() - timedelta(days=8)  # ADD THIS
-           return data
+
+    #-----------------------------------------------------
+    # change get_comment_create_data in django_comments_xtd/forms.py to cheat a
+    # bit and make Django believe that the comment was submitted 7 days ago:
+
+    def get_comment_create_data(self):
+      from datetime import timedelta                                     # ADD THIS
+
+        data = super(CommentForm, self).get_comment_create_data()
+        data['followup'] = self.cleaned_data['followup']
+        if settings.COMMENTS_XTD_CONFIRM_EMAIL:
+            # comment must be verified before getting approved
+            data['is_public'] = False
+            data['submit_date'] = datetime.datetime.now() - timedelta(days=8)  # ADD THIS
+        return data
 
 
 Try the simple demo site again and see that the `django_comments_xtd/discarded.html` template is rendered after clicking on the confirmation URL.
@@ -165,31 +165,31 @@ Django-comments-xtd inherits the flexibility of `django-contrib-comments framewo
 
 The configuration of the maximum thread level on a simple project is done by declaring the ``COMMENTS_XTD_MAX_THREAD_LEVEL`` in the ``settings.py`` file:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_MAX_THREAD_LEVEL = 2
+    COMMENTS_XTD_MAX_THREAD_LEVEL = 2
 
 
 Comments then could be nested up to level 2:
 
-   .. code-block:: text
+.. code-block:: text
 
-       <In an instance detail page that allows comments>
+    <In an instance detail page that allows comments>
 
-       First comment (level 0)
-         |-- Comment to First comment (level 1)
-           |-- Comment to Comment to First comment (level 2)
+    First comment (level 0)
+      |-- Comment to First comment (level 1)
+        |-- Comment to Comment to First comment (level 2)
 
 Comments posted to instances of every model in the project will allow up to level 2 of threading.
 
 On a project that allows users posting comments to instances of different models, the developer may want to declare a maximum thread level on a per ``app.model`` basis. For example, on an imaginary blog project with stories, quotes, diary entries and book/movie reviews, the developer might want to define a default, project wide, maximum thread level of 1 for any model and an specific maximum level of 5 for stories and quotes:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_MAX_THREAD_LEVEL = 1
-       COMMENTS_XTD_MAX_THREAD_LEVEL_BY_APP_MODEL = {
-           'blog.story': 5,
-           'blog.quote': 5,
-       }
+    COMMENTS_XTD_MAX_THREAD_LEVEL = 1
+    COMMENTS_XTD_MAX_THREAD_LEVEL_BY_APP_MODEL = {
+        'blog.story': 5,
+        'blog.quote': 5,
+    }
 
 So that ``blog.review`` and ``blog.diaryentry`` instances would support comments nested up to level 1, while ``blog.story`` and ``blog.quote`` instances would allow comments nested up to level 5.

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -14,65 +14,65 @@ Preparation
 
 First of all, install django-comments-xtd:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-       (venv)$ cd mysite
-       (venv)$ pip install django-comments-xtd
+    cd mysite
+    pip install django-comments-xtd
 
 Then edit the settings module and change your :setting:`INSTALLED_APPS` so that django_comments_xtd and django_comments are listed in this order. Also change the :setting:`COMMENTS_APP` and add the ``EMAIL_*`` settings to be able to send mail messages:
 
-   .. code-block:: python
+.. code-block:: python
 
-       INSTALLED_APPS = [
-           ...
-           'django_comments_xtd',
-           'django_comments',
-           ...
-       ]
-       ...
-       COMMENTS_APP = 'django_comments_xtd'
+    INSTALLED_APPS = [
+        ...
+        'django_comments_xtd',
+        'django_comments',
+        ...
+    ]
+    ...
+    COMMENTS_APP = 'django_comments_xtd'
 
-       # Either enable sending mail messages to the console:
-       EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+    # Either enable sending mail messages to the console:
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-       # Or set up the EMAIL_* settings so that Django can send emails:
-       EMAIL_HOST = "smtp.mail.com"
-       EMAIL_PORT = "587"
-       EMAIL_HOST_USER = "alias@mail.com"
-       EMAIL_HOST_PASSWORD = "yourpassword"
-       EMAIL_USE_TLS = True
-       DEFAULT_FROM_EMAIL = "Helpdesk <helpdesk@yourdomain>"
+    # Or set up the EMAIL_* settings so that Django can send emails:
+    EMAIL_HOST = "smtp.mail.com"
+    EMAIL_PORT = "587"
+    EMAIL_HOST_USER = "alias@mail.com"
+    EMAIL_HOST_PASSWORD = "yourpassword"
+    EMAIL_USE_TLS = True
+    DEFAULT_FROM_EMAIL = "Helpdesk <helpdesk@yourdomain>"
 
 
 Edit the urls module of the project and mount django_comments_xtd's URLs in the path in which you had django_comments' URLs, django_comments_xtd's URLs includes django_comments':
 
-   .. code-block:: python
+.. code-block:: python
 
-       from django.conf.urls import include, url
+    from django.conf.urls import include, url
 
-       urlpatterns = [
-           ...
-           url(r'^comments/', include('django_comments_xtd.urls')),
-           ...
-       ]
+    urlpatterns = [
+        ...
+        url(r'^comments/', include('django_comments_xtd.urls')),
+        ...
+    ]
 
 
 Now create the tables for django-comments-xtd:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-       (venv)$ python manage.py migrate
+    python manage.py migrate
 
-       
+
 Populate comment data
 =====================
 
 The following step will populate **XtdComment**'s table with data from the **Comment** model. For that purpose you can use the ``populate_xtdcomments`` management command:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-       (venv)$ python manage.py populate_xtdcomments
-       Added 3468 XtdComment object(s).
+    python manage.py populate_xtdcomments
+
 
 You can pass as many DB connections as you have defined in :setting:`DATABASES` and the command will run in each of the databases, populating the **XtdComment**'s table with data from the comments table existing in each database.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -20,20 +20,20 @@ To get started using django-comments-xtd follow these steps:
 
 #. Set the :setting:`COMMENTS_XTD_MAX_THREAD_LEVEL` to ``N``, being ``N`` the maximum level of threading up to which comments will be nested in your project.
 
-   .. code-block:: python
+.. code-block:: python
 
-       # 0: No nested comments:
-       #  Comment (level 0)
-       # 1: Nested up to level one:
-       #  Comment (level 0)
-       #   |-- Comment (level 1)
-       # 2: Nested up to level two:
-       #  Comment (level 0)
-       #   |-- Comment (level 1)
-       #        |-- Comment (level 2)
-       COMMENTS_XTD_MAX_THREAD_LEVEL = 2
+    # 0: No nested comments:
+    #  Comment (level 0)
+    # 1: Nested up to level one:
+    #  Comment (level 0)
+    #   |-- Comment (level 1)
+    # 2: Nested up to level two:
+    #  Comment (level 0)
+    #   |-- Comment (level 1)
+    #        |-- Comment (level 2)
+    COMMENTS_XTD_MAX_THREAD_LEVEL = 2
 
-   The thread level can also be established on a per ``<app>.<model>`` basis by using the :setting:`COMMENTS_XTD_MAX_THREAD_LEVEL_BY_APP_MODEL` setting. Use it to establish different maximum threading levels for each model. ie: no nested comments for quotes, up to thread level 2 for blog stories, etc.
+The thread level can also be established on a per ``<app>.<model>`` basis by using the :setting:`COMMENTS_XTD_MAX_THREAD_LEVEL_BY_APP_MODEL` setting. Use it to establish different maximum threading levels for each model. ie: no nested comments for quotes, up to thread level 2 for blog stories, etc.
 
 #. Set the :setting:`COMMENTS_XTD_CONFIRM_EMAIL` to ``True`` to require comment confirmation by email for no logged-in users.
 
@@ -41,23 +41,23 @@ To get started using django-comments-xtd follow these steps:
 
 #. Add the URLs of the comments-xtd app to your project's ``urls.py``:
 
-   .. code-block:: python
+.. code-block:: python
 
-       urlpatterns = [
-           ...
-           url(r'^comments/', include('django_comments_xtd.urls')),
-           ...
-       ]
+    urlpatterns = [
+        ...
+        url(r'^comments/', include('django_comments_xtd.urls')),
+        ...
+    ]
 
 #. Customize your project's email settings:
 
-   .. code-block:: python
+.. code-block:: python
 
-       EMAIL_HOST = "smtp.mail.com"
-       EMAIL_PORT = "587"
-       EMAIL_HOST_USER = "alias@mail.com"
-       EMAIL_HOST_PASSWORD = "yourpassword"
-       DEFAULT_FROM_EMAIL = "Helpdesk <helpdesk@yourdomain>"
+    EMAIL_HOST = "smtp.mail.com"
+    EMAIL_PORT = "587"
+    EMAIL_HOST_USER = "alias@mail.com"
+    EMAIL_HOST_PASSWORD = "yourpassword"
+    DEFAULT_FROM_EMAIL = "Helpdesk <helpdesk@yourdomain>"
 
 #. To allow a quick start django-comments-xtd makes use of `twitter-bootstrap`_. From django-comments-xtd v2.3 on it uses Twitter-Bootstrap v4. From django-comments-xtd v1.7.1 to v2.2 it uses Twitter-Bootstrap v3. If you want to build your own templates, use the `comments <https://django-contrib-comments.readthedocs.io/en/latest/quickstart.html#comment-template-tags>`_ templatetag module, provided by the `django-comments <https://django-contrib-comments.readthedocs.io/en/latest/index.html>`_ app. Create a ``comments`` directory in your templates directory and copy the templates you want to customise from the Django Comments Framework. The following are the most important:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -259,29 +259,29 @@ Defaults to ``True``.
 
 An example use:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_APP_MODEL_OPTIONS = {
-           'blog.post': {
-               'allow_flagging': True,
-               'allow_feedback': True,
-               'show_feedback': True,
-               'who_can_post': 'users'
-           }
-       }
+    COMMENTS_XTD_APP_MODEL_OPTIONS = {
+        'blog.post': {
+            'allow_flagging': True,
+            'allow_feedback': True,
+            'show_feedback': True,
+            'who_can_post': 'users'
+        }
+    }
 
 Defaults to:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_APP_MODEL_OPTIONS = {
-           'default': {
-               'allow_flagging': False,
-               'allow_feedback': False,
-               'show_feedback': False,
-               'who_can_post': 'all'
-           }
-       }
+    COMMENTS_XTD_APP_MODEL_OPTIONS = {
+        'default': {
+            'allow_flagging': False,
+            'allow_feedback': False,
+            'show_feedback': False,
+            'who_can_post': 'all'
+        }
+    }
 
 
 .. setting:: COMMENTS_XTD_API_USER_REPR
@@ -294,15 +294,15 @@ representation. It's used to produced the list of users who liked/disliked
 comments. By default it outputs the username, but it could perfectly return the
 full name:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_API_USER_REPR = lambda u: u.get_full_name()
+    COMMENTS_XTD_API_USER_REPR = lambda u: u.get_full_name()
 
 Defaults to:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_API_USER_REPR = lambda u: u.username
+    COMMENTS_XTD_API_USER_REPR = lambda u: u.username
 
 
 .. setting:: COMMENTS_XTD_API_DATETIME_FORMAT
@@ -312,15 +312,15 @@ Defaults to:
 
 **Optional**. Like global setting ``DATETIME_FORMAT``. It allows to format the ``submit_date`` retrieved using ``ReadCommentSerializer``. The given format string must be based on Django's `date formatting characters <https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#std-templatefilter-date>`_. It defaults to ``settings.DATETIME_FORMAT``:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_API_DATETIME_FORMAT = "Y-b-d H:i:s O"
+    COMMENTS_XTD_API_DATETIME_FORMAT = "Y-b-d H:i:s O"
 
 Defaults to:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_API_USER_REPR = settings.DATETIME_FORMAT
+    COMMENTS_XTD_API_USER_REPR = settings.DATETIME_FORMAT
 
 
 .. setting:: COMMENTS_XTD_API_GET_USER_AVATAR
@@ -332,15 +332,15 @@ Defaults to:
 
 **Optional**. Path to the function used by the web API to retrieve the user's image URL of the user associated with a comment. By default django-comments-xtd tries to retrieve images from Gravatar_. If you use the web API (the JavaScript plugin uses it) then you might want to write a function to provide the URL to the user's image from a comment object. You might be interested on the use case :ref:`ref-change-user-image-or-avatar`, which cover the topic in depth.
 
- .. code-block:: python
+.. code-block:: python
 
-     COMMENTS_XTD_API_GET_USER_AVATAR = "comp.utils.get_avatar_url"
+    COMMENTS_XTD_API_GET_USER_AVATAR = "comp.utils.get_avatar_url"
 
 The function used by default, **get_user_avatar** in ``django_comments_xtd/utils.py``, tries to fetch every user's image from Gravatar:
 
- .. code-block:: python
+.. code-block:: python
 
-     COMMENTS_XTD_API_GET_USER_AVATAR = "django_comments_xtd.utils.get_user_avatar"
+    COMMENTS_XTD_API_GET_USER_AVATAR = "django_comments_xtd.utils.get_user_avatar"
 
 .. setting:: COMMENTS_XTD_DEFAULT_FOLLOWUP
 

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -17,7 +17,7 @@ This page details the list of templates provided by django-comments-xtd. They ar
 
 ``email_confirmation_request``
 ------------------------------
-   
+
 As ``.html`` and ``.txt``, this template represents the confirmation message sent to the user when the **Send** button is clicked to post a comment. Both templates are sent in a multipart message, or only in text format if the :setting:`COMMENTS_XTD_SEND_HTML_EMAIL` setting is set to ``False``.
 
 In the context of the template the following objects are expected:
@@ -40,13 +40,13 @@ In the context of the template the following objects are expected:
 
  * A list of dictionaries called ``comments`` in which each element is a dictionary like:
 
-   .. code-block:: python
+.. code-block:: python
 
-       {
-           'comment': xtdcomment_object,
-           'children': [ list_of_child_xtdcomment_dicts ]
-       }
-   
+    {
+        'comment': xtdcomment_object,
+        'children': [ list_of_child_xtdcomment_dicts ]
+    }
+
 Optionally the following objects can be present in the template:
 
  * A boolean ``allow_flagging`` to indicate whether the user will have the capacity to suggest comment removal.
@@ -56,7 +56,7 @@ Optionally the following objects can be present in the template:
 .. index::
    single: comment_tree
    pair: template; comment_tree
-   
+
 ``user_feedback.html``
 ----------------------
 
@@ -93,7 +93,7 @@ The context of the template expects:
 --------------
 
 This template is rendered when the user click on the submit button of the form presented in the ``like.html`` template. The template is meant to thank the user for the feedback. The context for the template doesn't expect any specific object.
-   
+
 
 .. index::
    single: liked

--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -14,7 +14,7 @@ Django-comments-xtd provides 5 template tags and 3 filters. Load the module to m
 .. contents:: Table of Contents
    :depth: 1
    :local:
-    
+
 
 .. index::
    single: render_xtdcomment_tree
@@ -23,17 +23,18 @@ Django-comments-xtd provides 5 template tags and 3 filters. Load the module to m
 .. templatetag:: render_xtdcomment_tree
 
 .. _render-xtdcomment-tree:
-                 
+
 Tag ``render_xtdcomment_tree``
 ==============================
 
 Tag syntax:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% render_xtdcomment_tree [for <object>] [with var_name_1=<obj_1> var_name_2=<obj_2>]
-                                 [allow_flagging] [allow_feedback] [show_feedback]
-                                 [using <template>] %}
+      {% render_xtdcomment_tree
+          [for <object>] [with var_name_1=<obj_1> var_name_2=<obj_2>]
+          [allow_flagging] [allow_feedback] [show_feedback]
+          [using <template>] %}
 
 
 Renders the threaded structure of comments posted to the given object using the first template found from the list:
@@ -56,13 +57,13 @@ Example usage
 
 In the usual scenario the tag is used in the object detail template, i.e.: ``blog/article_detail.html``, to include all comments posted to the article, in a tree structure:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% render_xtdcomment_tree for article allow_flagging allow_feedback show_feedback  %}
+    {% render_xtdcomment_tree for article allow_flagging allow_feedback show_feedback  %}
 
 
-   
-       
+
+
 .. index::
    single: get_xtdcomment_tree
    pair: tag; get_xtdcomment_tree
@@ -74,42 +75,42 @@ Tag ``get_xtdcomment_tree``
 
 Tag syntax:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% get_xtdcomment_tree for [object] as [varname] [with_feedback] %}
+      {% get_xtdcomment_tree for [object] as [varname] [with_feedback] %}
 
 
 Returns a dictionary to the template context under the name given in ``[varname]`` with the comments posted to the given ``[object]``. The dictionary has the form:
 
-   .. code-block:: python
+.. code-block:: python
 
-       {
-           'comment': xtdcomment_object,
-           'children': [ list_of_child_xtdcomment_dicts ]
-       }
+    {
+        'comment': xtdcomment_object,
+        'children': [ list_of_child_xtdcomment_dicts ]
+    }
 
 The comments will be ordered by the ``thread_id`` and ``order`` within the thread, as stated by the setting :setting:`COMMENTS_XTD_LIST_ORDER`.
 
 When the optional argument ``with_feedback`` is specified the returned dictionary will contain two additional attributes with the list of users who liked the comment and the list of users who disliked it:
 
-   .. code-block:: python
+.. code-block:: python
 
-       {
-           'xtdcomment': xtdcomment_object,
-           'children': [ list_of_child_xtdcomment_dicts ],
-           'likedit': [user_a, user_b, ...],
-           'dislikedit': [user_n, user_m, ...]
-       }
+    {
+        'xtdcomment': xtdcomment_object,
+        'children': [ list_of_child_xtdcomment_dicts ],
+        'likedit': [user_a, user_b, ...],
+        'dislikedit': [user_n, user_m, ...]
+    }
 
-       
+
 Example usage
 -------------
 
 Get an ordered dictionary with the comments posted to a given blog story and store the dictionary in a template context variabled called ``comment_tree``:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% get_xtdcomment_tree for story as comments_tree with_feedback %}
+    {% get_xtdcomment_tree for story as comments_tree with_feedback %}
 
 
 .. index::
@@ -167,7 +168,7 @@ Get the list of the last 10 comments two models, ``Story`` and ``Quote``, have r
     {% endif %}
 
 
-    
+
 .. index::
    single: get_xtdcomment_count
    pair: tag; get_xtdcomment_count
@@ -238,15 +239,15 @@ This filter has been named ``xtd_comment_gravatar_url`` as oposed to simply ``gr
    pair: filter; render_markup_comment
 
 .. templatetag:: render_markup_comment
-   
+
 Filter ``render_markup_comment``
 ================================
 
 Filter syntax:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {{ comment.comment|render_markup_comment }}
+    {{ comment.comment|render_markup_comment }}
 
 
 Renders a comment using a markup language specified in the first line of the comment. It uses `django-markup <https://github.com/bartTC/django-markup>`_ to parse the comments with a markup language parser and produce the corresponding output.
@@ -256,16 +257,16 @@ Example usage
 
 A comment posted with a content like:
 
-   .. code-block:: text
+.. code-block:: text
 
-       #!markdown
-       An [example](http://url.com/ "Title")
+    #!markdown
+    An [example](http://url.com/ "Title")
 
 Would be rendered as a markdown text, producing the output:
 
-   .. code-block:: html
-       
-       <p><a href="http://url.com/" title="Title">example</a></p>
+.. code-block:: html
+
+    <p><a href="http://url.com/" title="Title">example</a></p>
 
 Available markup languages are:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -37,19 +37,23 @@ comments.
 Preparation
 ===========
 
-Before we install any package we will set up a virtualenv and install
-everything we need in it.
+Before we install any package we will set up a virtualenv:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-       $ mkdir ~/django-comments-xtd-tutorial
-       $ cd ~/django-comments-xtd-tutorial
-       $ virtualenv venv
-       $ source venv/bin/activate
-       (venv)$ pip install django-comments-xtd
-       (venv)$ wget https://github.com/danirus/django-comments-xtd/raw/master/example/tutorial.tar.gz
-       (venv)$ tar -xvzf tutorial.tar.gz
-       (venv)$ cd tutorial
+    mkdir ~/django-comments-xtd-tutorial
+    cd ~/django-comments-xtd-tutorial
+    virtualenv venv
+    source venv/bin/activate
+
+And we will install everything we need in it:
+
+.. code-block:: bash
+
+    pip install django-comments-xtd
+    wget https://github.com/danirus/django-comments-xtd/raw/master/example/tutorial.tar.gz
+    tar -xvzf tutorial.tar.gz
+    cd tutorial
 
 By installing django-comments-xtd we install all its dependencies, Django and
 django-contrib-comments among them. So we are ready to work on the project.
@@ -70,11 +74,11 @@ Take a look at the content of the tutorial directory, it contains:
 Let's finish the initial setup, load the fixtures and run the development
 server:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-       (venv)$ python manage.py migrate
-       (venv)$ python manage.py loaddata fixtures/*.json
-       (venv)$ python manage.py runserver
+    python manage.py migrate
+    python manage.py loaddata fixtures/*.json
+    python manage.py runserver
 
 Head to http://localhost:8000 and visit the tutorial site.
 
@@ -93,49 +97,49 @@ Configuration
 Now that the project is running we are ready to add comments. Edit the settings
 module, ``tutorial/settings.py``, and make the following changes:
 
-   .. code-block:: python
+.. code-block:: python
 
-       INSTALLED_APPS = [
-           ...
-           'django_comments_xtd',
-           'django_comments',
-           'blog',
-       ]
-       ...
-       COMMENTS_APP = 'django_comments_xtd'
+    INSTALLED_APPS = [
+        ...
+        'django_comments_xtd',
+        'django_comments',
+        'blog',
+    ]
+    ...
+    COMMENTS_APP = 'django_comments_xtd'
 
-       # Either enable sending mail messages to the console:
-       EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+    # Either enable sending mail messages to the console:
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-       # Or set up the EMAIL_* settings so that Django can send emails:
-       EMAIL_HOST = "smtp.mail.com"
-       EMAIL_PORT = "587"
-       EMAIL_HOST_USER = "alias@mail.com"
-       EMAIL_HOST_PASSWORD = "yourpassword"
-       EMAIL_USE_TLS = True
-       DEFAULT_FROM_EMAIL = "Helpdesk <helpdesk@yourdomain>"
+    # Or set up the EMAIL_* settings so that Django can send emails:
+    EMAIL_HOST = "smtp.mail.com"
+    EMAIL_PORT = "587"
+    EMAIL_HOST_USER = "alias@mail.com"
+    EMAIL_HOST_PASSWORD = "yourpassword"
+    EMAIL_USE_TLS = True
+    DEFAULT_FROM_EMAIL = "Helpdesk <helpdesk@yourdomain>"
 
 
 Edit the urls module of the project, ``tutorial/tutorial/urls.py`` and mount
 the URL patterns of django_comments_xtd in the path ``/comments/``. The urls
 installed with django_comments_xtd include django_comments' urls too:
 
-   .. code-block:: python
+.. code-block:: python
 
-       from django.urls import include, path
+    from django.urls import include, path
 
-       urlpatterns = [
-           ...
-           path(r'comments/', include('django_comments_xtd.urls')),
-           ...
-       ]
+    urlpatterns = [
+        ...
+        path(r'comments/', include('django_comments_xtd.urls')),
+        ...
+    ]
 
 
 Now let Django create the tables for the two new applications:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-       $ python manage.py migrate
+    python manage.py migrate
 
 
 Be sure that the domain field of the ``Site`` instance points to the correct
@@ -165,17 +169,17 @@ anonymous users too by simply setting :setting:`COMMENTS_XTD_CONFIRM_EMAIL` to
 
 Now let's append the following entries to the tutorial settings module:
 
-   .. code-block:: python
+.. code-block:: python
 
-       #  To help obfuscating comments before they are sent for confirmation.
-       COMMENTS_XTD_SALT = (b"Timendi causa est nescire. "
-                            b"Aequam memento rebus in arduis servare mentem.")
+    #  To help obfuscating comments before they are sent for confirmation.
+    COMMENTS_XTD_SALT = (b"Timendi causa est nescire. "
+                        b"Aequam memento rebus in arduis servare mentem.")
 
-       # Source mail address used for notifications.
-       COMMENTS_XTD_FROM_EMAIL = "webmaster@example.com"
+    # Source mail address used for notifications.
+    COMMENTS_XTD_FROM_EMAIL = "webmaster@example.com"
 
-       # Contact mail address to show in messages.
-       COMMENTS_XTD_CONTACT_EMAIL = "helpdesk@example.com"
+    # Contact mail address to show in messages.
+    COMMENTS_XTD_CONTACT_EMAIL = "helpdesk@example.com"
 
 
 Comments tags
@@ -184,29 +188,29 @@ Comments tags
 Next step consist of editing ``blog/post_detail.html`` and loading the
 ``comments`` templatetag module after the ``extends`` tag:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% extends "base.html" %}
-       {% load comments %}
+    {% extends "base.html" %}
+    {% load comments %}
 
 Now we will change the blog post detail template to:
 
- #. Show the number of comments posted to the blog story,
- #. List the comments already posted, and
- #. Show the comment form, so that comments can be sent.
+#. Show the number of comments posted to the blog story,
+#. List the comments already posted, and
+#. Show the comment form, so that comments can be sent.
 
 By using the :ttag:`get_comment_count` tag we will show the number of comments
 posted. Change the code around the link element to make it look as follows:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% get_comment_count for object as comment_count %}
-       <div class="py-4 text-center">
-         <a href="{% url 'blog:post-list' %}">Back to the post list</a>
-         &nbsp;&sdot;&nbsp;
-         {{ comment_count }} comment{{ comment_count|pluralize }}
-         ha{{ comment_count|pluralize:"s,ve" }} been posted.
-       </div>
+    {% get_comment_count for object as comment_count %}
+    <div class="py-4 text-center">
+      <a href="{% url 'blog:post-list' %}">Back to the post list</a>
+      &nbsp;&sdot;&nbsp;
+      {{ comment_count }} comment{{ comment_count|pluralize }}
+      ha{{ comment_count|pluralize:"s,ve" }} been posted.
+    </div>
 
 Now let's add the code to list the comments posted to the story. We can make
 use of two template tags, :ttag:`render_comment_list` and
@@ -217,11 +221,11 @@ template.
 When using the first, :ttag:`render_comment_list`, with a ``blog.post`` object,
 Django will look for the template ``list.html`` in the following directories:
 
-   .. code-block:: shell
+.. code-block:: shell
 
-       comments/blog/post/list.html
-       comments/blog/list.html
-       comments/list.html
+    comments/blog/post/list.html
+    comments/blog/list.html
+    comments/list.html
 
 Both, django-contrib-comments and django-comments-xtd, provide the last template
 of the list, ``comments/list.html``. The one provided within
@@ -236,14 +240,14 @@ Let's modify the ``blog/post_detail.html`` template to make use of the
 :ttag:`render_comment_list`. Add the following code at the end of the page,
 before the ``endblock`` tag:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% if comment_count %}
-       <hr/>
-       <div class="comments">
-         {% render_comment_list for object %}
-       </div>
-       {% endif %}
+    {% if comment_count %}
+    <hr/>
+    <div class="comments">
+      {% render_comment_list for object %}
+    </div>
+    {% endif %}
 
 
 Below the list of comments we want to display the comment form. There are two
@@ -255,16 +259,16 @@ control over the fields.
 We will use the first tag, :ttag:`render_comment_form`. Again, add the
 following code before the ``endblock`` tag:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% if object.allow_comments %}
-       <div class="card card-block mb-5">
-         <div class="card-body">
-           <h4 class="card-title text-center pb-3">Post your comment</h4>
-             {% render_comment_form for object %}
-         </div>
-       </div>
-       {% endif %}
+    {% if object.allow_comments %}
+    <div class="card card-block mb-5">
+      <div class="card-body">
+        <h4 class="card-title text-center pb-3">Post your comment</h4>
+          {% render_comment_form for object %}
+      </div>
+    </div>
+    {% endif %}
 
 
 .. note:: The ``{% if object.allow_comments %}`` and corresponding ``{% endif %}`` are not necessary in your code. I use it in this tutorial (and in the demo sites) as a way to disable comments whenever the author of a blog post decides so. It has been mentioned `here <https://github.com/danirus/django-comments-xtd/issues/108>`_ too.
@@ -274,22 +278,22 @@ Finally, before completing this first set of changes, we could show the number
 of comments along with post titles in the blog's home page. For this we have to
 edit ``blog/post_list.html`` and make the following changes:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% extends "base.html" %}
-       {% load comments %}
+    {% extends "base.html" %}
+    {% load comments %}
 
-       ...
-           {% for object in object_list %}
-           ...
-           {% get_comment_count for object as comment_count %}
-           <p class="date">Published {{ object.publish }}
-             {% if comment_count %}
-             &sdot;&nbsp;{{ comment_count }} comment{{ comment_count|pluralize }}
-             {% endif %}
-           </p>
-           ...
-           {% endfor %}
+    ...
+        {% for object in object_list %}
+        ...
+        {% get_comment_count for object as comment_count %}
+        <p class="date">Published {{ object.publish }}
+          {% if comment_count %}
+          &sdot;&nbsp;{{ comment_count }} comment{{ comment_count|pluralize }}
+          {% endif %}
+        </p>
+        ...
+        {% endfor %}
 
 
 Now we are ready to send comments. If you are logged in in the admin site, your
@@ -334,11 +338,11 @@ flagged for moderation. Also we want Django to send an email to registered
 Let's start adding our email address to the :setting:`MANAGERS` in the
 ``tutorial/settings.py`` module:
 
-   .. code-block:: python
+.. code-block:: python
 
-       MANAGERS = (
-           ('Joe Bloggs', 'joe.bloggs@example.com'),
-       )
+    MANAGERS = (
+        ('Joe Bloggs', 'joe.bloggs@example.com'),
+    )
 
 
 Now we will create a new ``Moderator`` class that inherits from Django Comments
@@ -355,23 +359,23 @@ for non-registered users, nested comments, follow-up notifications, etc.
 
 Let's add those changes to the ``blog/model.py`` file:
 
-   .. code-block:: python
+.. code-block:: python
 
-       ...
-       # Append these imports below the current ones.
-       from django_comments.moderation import CommentModerator
-       from django_comments_xtd.moderation import moderator
+    ...
+    # Append these imports below the current ones.
+    from django_comments.moderation import CommentModerator
+    from django_comments_xtd.moderation import moderator
 
-       ...
+    ...
 
-       # Add this code at the end of the file.
-       class PostCommentModerator(CommentModerator):
-           email_notification = True
-           auto_moderate_field = 'publish'
-           moderate_after = 365
+    # Add this code at the end of the file.
+    class PostCommentModerator(CommentModerator):
+        email_notification = True
+        auto_moderate_field = 'publish'
+        moderate_after = 365
 
 
-       moderator.register(Post, PostCommentModerator)
+    moderator.register(Post, PostCommentModerator)
 
 
 That makes it, moderation is ready. Visit any of the blog posts with a
@@ -423,9 +427,9 @@ moderation comments containing badwords_.
 Let us first disable comment confirmation. Edit the ``tutorial/settings.py``
 file and add:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_CONFIRM_EMAIL = False
+    COMMENTS_XTD_CONFIRM_EMAIL = False
 
 
 django-comments-xtd comes with a **Moderator** class that inherits from
@@ -433,16 +437,16 @@ django-comments-xtd comes with a **Moderator** class that inherits from
 filtering for us. We just have to change ``blog/models.py`` and replace
 ``CommentModerator`` with ``SpamModerator``, as follows:
 
-   .. code-block:: python
+.. code-block:: python
 
-       # Remove the CommentModerator imports and leave only this:
-       from django_comments_xtd.moderation import moderator, SpamModerator
+    # Remove the CommentModerator imports and leave only this:
+    from django_comments_xtd.moderation import moderator, SpamModerator
 
-       # Our class Post PostCommentModerator now inherits from SpamModerator
-       class PostCommentModerator(SpamModerator):
-           ...
+    # Our class Post PostCommentModerator now inherits from SpamModerator
+    class PostCommentModerator(SpamModerator):
+        ...
 
-       moderator.register(Post, PostCommentModerator)
+    moderator.register(Post, PostCommentModerator)
 
 
 Now we can add a domain to the ``BlackListed`` model in the admin_ interface.
@@ -475,61 +479,65 @@ We assume we already have a list of ``BlackListed`` domains and we don't need
 further spam control. So we will disable comment confirmation by email. Edit
 the ``settings.py`` file:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_CONFIRM_EMAIL = False
+    COMMENTS_XTD_CONFIRM_EMAIL = False
 
 
 Now edit ``blog/models.py`` and add the code corresponding to our new
 ``PostCommentModerator``:
 
-   .. code-block:: python
+.. code-block:: python
 
-       # Below the other imports:
-       from django_comments_xtd.moderation import moderator, SpamModerator
-       from blog.badwords import badwords
+    # Below the other imports:
+    from django_comments_xtd.moderation import moderator, SpamModerator
+    from blog.badwords import badwords
 
-       ...
+    ...
 
-       class PostCommentModerator(SpamModerator):
-           email_notification = True
+    class PostCommentModerator(SpamModerator):
+        email_notification = True
 
-           def moderate(self, comment, content_object, request):
-               # Make a dictionary where the keys are the words of the message
-               # and the values are their relative position in the message.
-               def clean(word):
-                   ret = word
-                   if word.startswith('.') or word.startswith(','):
-                       ret = word[1:]
-                   if word.endswith('.') or word.endswith(','):
-                       ret = word[:-1]
-                   return ret
+        def moderate(self, comment, content_object, request):
+            # Make a dictionary where the keys are the words of the message
+            # and the values are their relative position in the message.
+            def clean(word):
+                ret = word
+                if word.startswith('.') or word.startswith(','):
+                    ret = word[1:]
+                if word.endswith('.') or word.endswith(','):
+                    ret = word[:-1]
+                return ret
 
-               lowcase_comment = comment.comment.lower()
-               msg = dict([(clean(w), i)
-                           for i, w in enumerate(lowcase_comment.split())])
-               for badword in badwords:
-                   if isinstance(badword, str):
-                       if lowcase_comment.find(badword) > -1:
-                           return True
-                   else:
-                       lastindex = -1
-                       for subword in badword:
-                           if subword in msg:
-                               if lastindex > -1:
-                                   if msg[subword] == (lastindex + 1):
-                                       lastindex = msg[subword]
-                               else:
-                                   lastindex = msg[subword]
-                           else:
-                               break
-                       if msg.get(badword[-1]) and msg[badword[-1]] == lastindex:
-                           return True
-               return super(PostCommentModerator, self).moderate(comment,
-                                                                 content_object,
-                                                                 request)
+            lowcase_comment = comment.comment.lower()
+            msg = dict([
+                (clean(w), i)
+                for i, w in enumerate(lowcase_comment.split())
+            ])
 
-       moderator.register(Post, PostCommentModerator)
+            for badword in badwords:
+                if isinstance(badword, str):
+                    if lowcase_comment.find(badword) > -1:
+                        return True
+                else:
+                    lastindex = -1
+                    for subword in badword:
+                        if subword in msg:
+                            if lastindex > -1:
+                                if msg[subword] == (lastindex + 1):
+                                    lastindex = msg[subword]
+                            else:
+                                lastindex = msg[subword]
+                        else:
+                            break
+                    if msg.get(badword[-1]) and msg[badword[-1]] == lastindex:
+                        return True
+
+            return super(PostCommentModerator, self).moderate(
+                comment, content_object, request
+            )
+
+    moderator.register(Post, PostCommentModerator)
 
 
 Now we can try to send a comment with any of the bad words listed in badwords_.
@@ -581,10 +589,10 @@ list newer comments first.
 Let's start by editing ``tutorial/settings.py`` to set up the maximum thread
 level to 1 and a comment ordering such that newer comments are retrieve first:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_MAX_THREAD_LEVEL = 1  # default is 0
-       COMMENTS_XTD_LIST_ORDER = ('-thread_id', 'order')  # default is ('thread_id', 'order')
+    COMMENTS_XTD_MAX_THREAD_LEVEL = 1  # default is 0
+    COMMENTS_XTD_LIST_ORDER = ('-thread_id', 'order')  # default is ('thread_id', 'order')
 
 Now we have to modify the blog post detail template to load the ``comments_xtd``
 templatetag and make use of :ttag:`render_xtdcomment_tree`. We also want to move
@@ -593,46 +601,46 @@ below the blog post, followed by the list of comments.
 
 Edit ``blog/post_detail.html`` to make it look like follows:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% extends "base.html" %}
-       {% load comments %}
-       {% load comments_xtd %}
+    {% extends "base.html" %}
+    {% load comments %}
+    {% load comments_xtd %}
 
-       {% block title %}{{ object.title }}{% endblock %}
+    {% block title %}{{ object.title }}{% endblock %}
 
-       {% block content %}
-       <div class="pb-3">
-         <h1 class="page-header text-center">{{ object.title }}</h1>
-         <p class="small text-center">{{ object.publish|date:"l, j F Y" }}</p>
-       </div>
-       <div>
-         {{ object.body|linebreaks }}
-       </div>
+    {% block content %}
+    <div class="pb-3">
+      <h1 class="page-header text-center">{{ object.title }}</h1>
+      <p class="small text-center">{{ object.publish|date:"l, j F Y" }}</p>
+    </div>
+    <div>
+      {{ object.body|linebreaks }}
+    </div>
 
-       {% get_comment_count for object as comment_count %}
-       <div class="py-4 text-center">
-         <a href="{% url 'blog:post-list' %}">Back to the post list</a>
-         &nbsp;&sdot;&nbsp;
-         {{ comment_count }} comment{{ comment_count|pluralize }}
-         ha{{ comment_count|pluralize:"s,ve"}} been posted.
-       </div>
+    {% get_comment_count for object as comment_count %}
+    <div class="py-4 text-center">
+      <a href="{% url 'blog:post-list' %}">Back to the post list</a>
+      &nbsp;&sdot;&nbsp;
+      {{ comment_count }} comment{{ comment_count|pluralize }}
+      ha{{ comment_count|pluralize:"s,ve"}} been posted.
+    </div>
 
-       {% if object.allow_comments %}
-       <div class="comment mt-3 mb-5">
-         <h4 class="text-center mb-4">Your comment</h4>
-         <div class="card pt-4">
-           {% render_comment_form for object %}
-         </div>
-       </div>
-       {% endif %}
+    {% if object.allow_comments %}
+    <div class="comment mt-3 mb-5">
+      <h4 class="text-center mb-4">Your comment</h4>
+      <div class="card pt-4">
+        {% render_comment_form for object %}
+      </div>
+    </div>
+    {% endif %}
 
-       {% if comment_count %}
-       <ul class="media-list">
-         {% render_xtdcomment_tree for object %}
-       </ul>
-       {% endif %}
-       {% endblock %}
+    {% if comment_count %}
+    <ul class="media-list">
+      {% render_xtdcomment_tree for object %}
+    </ul>
+    {% endif %}
+    {% endblock %}
 
 
 The tag :ttag:`render_xtdcomment_tree` renders the template
@@ -664,14 +672,14 @@ If we wanted to disable nested comments site wide, and enable nested comments
 up to level one for blog posts, we would set it up as follows in our
 ``settings.py`` module:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_MAX_THREAD_LEVEL = 0  # site wide default
-       COMMENTS_XTD_MAX_THREAD_LEVEL_BY_APP_MODEL = {
-           # Objects of the app blog, model post, can be nested
-           # up to thread level 1.
-   	       'blog.post': 1,
-       }
+    COMMENTS_XTD_MAX_THREAD_LEVEL = 0  # site wide default
+    COMMENTS_XTD_MAX_THREAD_LEVEL_BY_APP_MODEL = {
+        # Objects of the app blog, model post, can be nested
+        # up to thread level 1.
+        'blog.post': 1,
+    }
 
 The ``nested_count`` field
 --------------------------
@@ -716,16 +724,16 @@ actions users can perform on comments: flag them as inappropriate, like/dislike 
 
 It defaults to:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_APP_MODEL_OPTIONS = {
-           'default': {
-               'allow_flagging': False,
-               'allow_feedback': False,
-               'show_feedback': False,
-               'who_can_post': 'all'  # Valid values: 'all', users'
-           }
-       }
+    COMMENTS_XTD_APP_MODEL_OPTIONS = {
+        'default': {
+            'allow_flagging': False,
+            'allow_feedback': False,
+            'show_feedback': False,
+            'who_can_post': 'all'  # Valid values: 'all', users'
+        }
+    }
 
 We will go through the first three options in the following sections. As for the last option, *who_can_post*, I recommend you to read the special use case :ref:`ref-recipe-only-signed-in-can-comment`, that explains the topic in depth.
 
@@ -737,12 +745,12 @@ Enabling the comment removal flag is about including the **allow_flagging**
 argument in the ``render_xtdcomment_tree`` template tag. Edit the
 ``blog/post_detail.html`` template and append the argument:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       ...
-       <ul class="media-list">
-         {% render_xtdcomment_tree for object allow_flagging %}
-       </ul>
+    ...
+    <ul class="media-list">
+      {% render_xtdcomment_tree for object allow_flagging %}
+    </ul>
 
 
 The **allow_flagging** argument makes the templatetag populate a variable
@@ -750,15 +758,15 @@ The **allow_flagging** argument makes the templatetag populate a variable
 ``django_comments_xtd/comment_tree.html`` is rendered. Edit now the settings
 module and enable the ``allow_flagging`` option for the ``blog.post``:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_APP_MODEL_OPTIONS = {
-           'blog.post': {
-               'allow_flagging': True,
-               'allow_feedback': False,
-               'show_feedback': False,
-           }
-       }
+    COMMENTS_XTD_APP_MODEL_OPTIONS = {
+        'blog.post': {
+            'allow_flagging': True,
+            'allow_feedback': False,
+            'show_feedback': False,
+        }
+    }
 
 Now let's suggest a removal. First we need to login in the admin_ interface so
 that we are not an anonymous user. Then we can visit any of the blog posts we
@@ -801,15 +809,15 @@ class **SpamModerator**, which inherits from **XtdCommentModerator**, just add
 ``removal_suggestion_notification = True`` to your ``PostCommentModeration``
 class. Otherwise add the following code:
 
-   .. code-block:: python
+.. code-block:: python
 
-      from django_comments_xtd.moderation import moderator, XtdCommentModerator
+  from django_comments_xtd.moderation import moderator, XtdCommentModerator
 
-      ...
-      class PostCommentModerator(XtdCommentModerator):
-          removal_suggestion_notification = True
+  ...
+  class PostCommentModerator(XtdCommentModerator):
+      removal_suggestion_notification = True
 
-      moderator.register(Post, PostCommentModerator)
+  moderator.register(Post, PostCommentModerator)
 
 Be sure that ``PostCommentModerator`` is the only moderation class registered
 for the ``Post`` model, and be sure as well that the :setting:`MANAGERS`
@@ -836,11 +844,11 @@ like/dislike buttons is about adding an argument to the
 ``render_xtdcomment_tree``, the argument ``allow_feedback``.
 Edit the ``blog/post_detail.html`` template and add the new argument:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       <ul class="media-list">
-         {% render_xtdcomment_tree for object allow_flagging allow_feedback %}
-       </ul>
+    <ul class="media-list">
+      {% render_xtdcomment_tree for object allow_flagging allow_feedback %}
+    </ul>
 
 
 The **allow_feedback** argument makes the templatetag populate a variable
@@ -849,15 +857,15 @@ The **allow_feedback** argument makes the templatetag populate a variable
 module and enable the ``allow_feedback`` option for the ``blog.post``
 **app.label** pair:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_APP_MODEL_OPTIONS = {
-           'blog.post': {
-               'allow_flagging': True,
-               'allow_feedback': True,
-               'show_feedback': False,
-           }
-       }
+    COMMENTS_XTD_APP_MODEL_OPTIONS = {
+        'blog.post': {
+            'allow_flagging': True,
+            'allow_feedback': True,
+            'show_feedback': False,
+        }
+    }
 
 The blog post detail template is ready to show the like/dislike buttons,
 refresh your browser.
@@ -881,46 +889,46 @@ users who actually liked/disliked comments. Again addind an argument to the
 ``blog/post_detail.html`` and add the argument ``show_feedback``
 to the template tag:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       [...]
-       <ul class="media-list">
-         {% render_xtdcomment_tree for object allow_flagging allow_feedback show_feedback %}
-       </ul>
-       {% endif %}
-       {% endblock %}
+    [...]
+    <ul class="media-list">
+      {% render_xtdcomment_tree for object allow_flagging allow_feedback show_feedback %}
+    </ul>
+    {% endif %}
+    {% endblock %}
 
-       {% block extra-js %}
-       <script
-         src="https://code.jquery.com/jquery-3.3.1.min.js"
-         crossorigin="anonymous"></script>
-       <script
-         src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
-         integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
-         crossorigin="anonymous"></script>
-       <script
-         src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
-         integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
-         crossorigin="anonymous"></script>
-       <script>
-         $(function() {
-           $('[data-toggle="tooltip"]').tooltip({html: true});
-         });
-       </script>
-       {% endblock %}
+    {% block extra-js %}
+    <script
+      src="https://code.jquery.com/jquery-3.3.1.min.js"
+      crossorigin="anonymous"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
+      integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
+      crossorigin="anonymous"></script>
+    <script
+      src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
+      integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
+      crossorigin="anonymous"></script>
+    <script>
+      $(function() {
+        $('[data-toggle="tooltip"]').tooltip({html: true});
+      });
+    </script>
+    {% endblock %}
 
 Also change the settings and enable the ``show_feedback`` option for
 ``blog.post``:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_APP_MODEL_OPTIONS = {
-           'blog.post': {
-               'allow_flagging': True,
-               'allow_feedback': True,
-               'show_feedback': True,
-           }
-       }
+    COMMENTS_XTD_APP_MODEL_OPTIONS = {
+        'blog.post': {
+            'allow_flagging': True,
+            'allow_feedback': True,
+            'show_feedback': True,
+        }
+    }
 
 We loaded jQuery and twitter-bootstrap_ libraries from their respective default
 CDNs as the code above uses bootstrap's tooltip functionality to show the list
@@ -967,19 +975,19 @@ Now we will install `django-markdown2
 <https://pypi.python.org/pypi/django-markdown2>`_, and create the template
 directory and the template file:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-       (venv)$ pip install django-markdown2
-       (venv)$ mkdir -p templates/includes/django_comments_xtd/
-       (venv)$ touch templates/includes/django_comments_xtd/comment_content.html
+    (venv)$ pip install django-markdown2
+    (venv)$ mkdir -p templates/includes/django_comments_xtd/
+    (venv)$ touch templates/includes/django_comments_xtd/comment_content.html
 
 We have to add ``django_markdown2`` to our :setting:`INSTALLED_APPS`, and add
 the following template code to the file ``comment_content.html`` we just created:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
-       {% load md2 %}
-       {{ content|markdown:"safe, code-friendly, code-color" }}
+    {% load md2 %}
+    {{ content|markdown:"safe, code-friendly, code-color" }}
 
 Now our project is ready to show comments posted in Markdown. After reloading,
 the comment's page will look like this:
@@ -1015,19 +1023,19 @@ The JavaScript plugin uses the Web API provided within the app. In order to
 enable it install the `django-rest-framework
 <http://www.django-rest-framework.org/>`_:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-       (venv)$ pip install djangorestframework
+  pip install djangorestframework
 
 Once installed, add it to our tutorial :setting:`INSTALLED_APPS` setting:
 
-   .. code-block:: python
+.. code-block:: python
 
-       INSTALLED_APPS = [
-           ...
-           'rest_framework',
-           ...
-       ]
+    INSTALLED_APPS = [
+        ...
+        'rest_framework',
+        ...
+    ]
 
 To know more about the Web API provided by django-comments-xtd read on the
 :doc:`webapi` page.
@@ -1041,15 +1049,15 @@ flag comments for removal (allow_flagging option), to like/dislike comments
 (allow_feedback), and we want users to see the list of people who
 liked/disliked comments:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_APP_MODEL_OPTIONS = {
-           'blog.post': {
-               'allow_flagging': True,
-               'allow_feedback': True,
-               'show_feedback': True,
-           }
-       }
+    COMMENTS_XTD_APP_MODEL_OPTIONS = {
+        'blog.post': {
+            'allow_flagging': True,
+            'allow_feedback': True,
+            'show_feedback': True,
+        }
+    }
 
 The i18n JavaScript Catalog
 ---------------------------
@@ -1068,14 +1076,14 @@ has it), but we will not remove its support from the plugin, we will simply
 enable the JavaScript Catalog URL, so that the plugin can access its functions.
 Edit ``tutorial/urls.py`` and add the following url:
 
-   .. code-block:: python
+.. code-block:: python
 
-       from django.views.i18n import JavaScriptCatalog
+    from django.views.i18n import JavaScriptCatalog
 
-       urlpatterns = [
-           ...
-           path(r'jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
-       ]
+    urlpatterns = [
+        ...
+        path(r'jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
+    ]
 
 In the next section we will use the new URL to load the i18n JavaScript catalog.
 
@@ -1084,7 +1092,7 @@ Load the plugin
 
 Now let's edit ``blog/post_detail.html`` and make it look as follows:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
     {% extends "base.html" %}
     {% load static %}
@@ -1113,14 +1121,14 @@ Now let's edit ``blog/post_detail.html`` and make it look as follows:
     <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
     <script>
-     window.comments_props = {% get_commentbox_props for object %};
-     window.comments_props_override = {
-         allow_comments: {%if object.allow_comments%}true{%else%}false{%endif%},
-         allow_feedback: true,
-         show_feedback: true,
-         allow_flagging: true,
-         polling_interval: 5000  // In milliseconds.
-     };
+      window.comments_props = {% get_commentbox_props for object %};
+      window.comments_props_override = {
+          allow_comments: {%if object.allow_comments%}true{%else%}false{%endif%},
+          allow_feedback: true,
+          show_feedback: true,
+          allow_flagging: true,
+          polling_interval: 5000  // In milliseconds.
+      };
     </script>
     <script
       src="https://code.jquery.com/jquery-3.3.1.min.js"
@@ -1148,15 +1156,15 @@ Now let's edit ``blog/post_detail.html`` and make it look as follows:
 The blog post page is now ready to handle comments through the JavaScript
 plugin, including the following features:
 
- #. Post comments.
- #. Preview comments, with instant preview update while typing.
- #. Reply comment in the same page, with instant preview while typing.
- #. Notifications of new incoming comments using active polling (override
-    *polling_interval* parameter, see the content of first *<script>* tag in
-    the code above).
- #. Button to reload the tree of comments, highlighting new comments (see
+#. Post comments.
+#. Preview comments, with instant preview update while typing.
+#. Reply comment in the same page, with instant preview while typing.
+#. Notifications of new incoming comments using active polling (override
+   *polling_interval* parameter, see the content of first *<script>* tag in
+   the code above).
+#. Button to reload the tree of comments, highlighting new comments (see
     image below).
- #. Immediate like/dislike actions.
+#. Immediate like/dislike actions.
 
 .. image:: images/update-comment-tree.png
 

--- a/docs/usecases/only-signed-in-can-comment.rst
+++ b/docs/usecases/only-signed-in-can-comment.rst
@@ -37,16 +37,16 @@ testing comments to see that visitors and registered users can comment, add the
 :setting:`COMMENTS_XTD_APP_MODEL_OPTIONS` entry at the bottom of the
 ``settings.py`` module to allow only registered users to post comments:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_APP_MODEL_OPTIONS = {
-           'default': {
-               'allow_flagging': False,
-               'allow_feedback': False,
-               'show_feedback': False,
-               'who_can_post': 'users'
-           }
-       }
+    COMMENTS_XTD_APP_MODEL_OPTIONS = {
+        'default': {
+            'allow_flagging': False,
+            'allow_feedback': False,
+            'show_feedback': False,
+            'who_can_post': 'users'
+        }
+    }
 
 Once the change is saved and Django has reloaded check that, as before,
 registered users can comment without issues, however visitors get the HTTP-400
@@ -61,7 +61,7 @@ As an example, here is a modified version of the ``article_detail.html``
 template of the Simple project that displays a message with a link to the login
 page when the user is not authenticated:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
     [...]
 
@@ -110,16 +110,16 @@ the :setting:`COMMENTS_XTD_APP_MODEL_OPTIONS` at the bottom of the
 ``settings.py`` and append the pair ``'who_can_post': 'users'`` to the
 quotes app dictionary:
 
-   .. code-block:: python
+.. code-block:: python
 
-       COMMENTS_XTD_APP_MODEL_OPTIONS = {
-           'quotes.quote': {
-               'allow_flagging': True,
-               'allow_feedback': True,
-               'show_feedback': True,
-               'who_can_post': 'users'
-           }
-       }
+    COMMENTS_XTD_APP_MODEL_OPTIONS = {
+        'quotes.quote': {
+            'allow_flagging': True,
+            'allow_feedback': True,
+            'show_feedback': True,
+            'who_can_post': 'users'
+        }
+    }
 
 Once changes are saved and Django has restarted see that registered users can
 comment without issues. However visitors get the HTTP-400 page (Bad Request).
@@ -129,7 +129,7 @@ have to edit the ``templates/quotes/quote_detail.html`` file and be sure
 that the block that renders the comment form is not displayed when the user
 browsing the site is a mere visitor. The following changes will make it:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
     [...] around line 41...
 
@@ -202,7 +202,7 @@ put content in this hidden block in the ``articles_detail.html``. Add the
 following HTML code before the script tags in the ``base.html`` in the
 ``example/comp/templates`` directory:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
     [...] around line 67, right before the first <script> tag...
 
@@ -215,7 +215,7 @@ following HTML code before the script tags in the ``base.html`` in the
 
 Add the following code to ``templates/articles/article_detail.html``:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
     [...] around line 46, right before the {% block extra_js %}...
 
@@ -227,7 +227,7 @@ And finally create the file ``only_users_can_post.html`` within the
 ``comp/templates/django_comments_xtd`` directory, with the following content
 in it:
 
-   .. code-block:: html+django
+.. code-block:: html+django
 
     <div id="only-users-can-post-{{ html_id_suffix }}">
       <p class="text-center">Only registered users can post comments. Please,


### PR DESCRIPTION
This PR fixes the code-blocks in the docs.
They were indented, causing Sphinx to interpret them as codeblocks first.