### PR TITLE
feat(react): on the fly

### DIFF
--- a/django_comments_xtd/static/django_comments_xtd/js/src/index.js
+++ b/django_comments_xtd/static/django_comments_xtd/js/src/index.js
@@ -3,9 +3,51 @@ import ReactDOM from 'react-dom';
 
 import { App } from './app.jsx';
 
-const root = ReactDOM.createRoot(document.getElementById('comments'));
-root.render(
-  React.createElement(App,
-    Object.assign(window.comments_props, window.comments_props_override)
-  )
-);
+function execute_xtd() {
+  var comments = document.querySelectorAll('#comments, .comments');
+  var props = '';
+  if (typeof window.comments_props != "undefined") {
+    props = Object.assign(window.comments_props, window.comments_props_override);
+  }
+  if (NodeList.prototype.isPrototypeOf(comments)) {
+    comments.forEach(async (item) => {
+      const root = ReactDOM.createRoot(item);
+      var _props = props;
+      if (item.querySelector('.comments-props') != null) {
+        _props = JSON.parse(item.querySelector('.comments-props').getAttribute('data-comments'));
+      }
+      root.render(
+        React.createElement(App, _props)
+      )
+    });
+  }
+}
+
+// https://stackoverflow.com/a/61511955/1902215
+function waitForElm(selector) {
+  return new Promise(resolve => {
+    if (document.querySelector(selector)) {
+      return resolve(document.querySelector(selector));
+    }
+
+    const observer = new MutationObserver(mutations => {
+      if (document.querySelector(selector)) {
+        observer.disconnect();
+        resolve(document.querySelector(selector));
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+  });
+}
+
+if (typeof window.comments_props != 'undefined') {
+  execute_xtd();
+}
+
+waitForElm('#comments, .comments').then((elm) => {
+  execute_xtd();
+});

--- a/django_comments_xtd/static/django_comments_xtd/js/src/index.js
+++ b/django_comments_xtd/static/django_comments_xtd/js/src/index.js
@@ -44,9 +44,7 @@ function waitForElm(selector) {
   });
 }
 
-if (typeof window.comments_props != 'undefined') {
-  execute_xtd();
-}
+execute_xtd();
 
 waitForElm('#comments, .comments').then((elm) => {
   execute_xtd();


### PR DESCRIPTION
Ref: https://github.com/danirus/django-comments-xtd/issues/418

So this PR implements:

* Various check to avoid crashes if `window.comments_props` is not defined or if the `comments` div not exists
* Add the support to create div also with a `.comments` class, not just the ID
* Load the proprieties also from the HTML itself, in this way you don't need anymore a unique global variable but for every box comments you can have specific with different app initiation
  *  Support the old system and the new one
* Check for new comments with `mutationObserver` in this way the new comments can be added in the page as you want on the fly

This requires some updates to the documentation:

```
<div class="comments">
  <span class="comments-props" data-comments='{% get_commentbox_props for object %}'></span>

  {% render_xtdcomment_tree for object allow_flagging allow_feedback %}
</div>
```