### PR TITLE
COMMENTS_XTD_APP_MODEL_OPTIONS used on get_commentbox_props

### DIFF
--- a/django_comments_xtd/api/frontend.py
+++ b/django_comments_xtd/api/frontend.py
@@ -143,6 +143,10 @@ class CommentBoxDriver(object):
             d['like_url'] = reverse("comments-xtd-like", args=(0,))
             d['dislike_url'] = reverse("comments-xtd-dislike", args=(0,))
 
+        defaults_per_model = settings.COMMENTS_XTD_APP_MODEL_OPTIONS[str(ctype).replace(' | ', '.')]
+        for i in defaults_per_model:
+            d[i] = defaults_per_model[i]
+
         return d
 
 


### PR DESCRIPTION
In this way the settings parameter can overwrite the values for the specific model