### PR TITLE
Switch Django intersphinx to the dev version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -240,8 +240,8 @@ man_pages = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('http://docs.python.org/', None),
-    'django': ('http://docs.djangoproject.com/en/stable',
-               'http://docs.djangoproject.com/en/stable/_objects'),
+    'django': ('https://docs.djangoproject.com/en/dev/',
+               'https://docs.djangoproject.com/en/dev/_objects/'),
     'comments': ('https://django-contrib-comments.readthedocs.io/en/latest/',
                  None)
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=6,<8
 sphinx_copybutton>=0.5.0,<1.0.0
-sphinx-nefertiti>=0.3.3
+sphinx-nefertiti>=0.4.1


### PR DESCRIPTION
This PR fixes issue #428, which is about the intersphinx inventory of objects for Django not having the usual links. In this PR I switch to the dev inventory which seems to work as expected.