### PR TITLE
Fix docs: remove 'v' from version dropdown

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,7 +151,7 @@ html_theme_options = {
 
     "current_version": release,
     "versions": [
-        ("v%s" % item, docs_url.format(release=item)) for item in releases
+        (item, docs_url.format(release=item)) for item in releases
     ],
 
     "header_links": [

--- a/docs/static/chat-text-fill.svg
+++ b/docs/static/chat-text-fill.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chat-text-fill" viewBox="0 0 16 16">
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-chat-text-fill" viewBox="0 0 16 16">
   <path d="M16 8c0 3.866-3.582 7-8 7a9 9 0 0 1-2.347-.306c-.584.296-1.925.864-4.181 1.234-.2.032-.352-.176-.273-.362.354-.836.674-1.95.77-2.966C.744 11.37 0 9.76 0 8c0-3.866 3.582-7 8-7s8 3.134 8 7M4.5 5a.5.5 0 0 0 0 1h7a.5.5 0 0 0 0-1zm0 2.5a.5.5 0 0 0 0 1h7a.5.5 0 0 0 0-1zm0 2.5a.5.5 0 0 0 0 1h4a.5.5 0 0 0 0-1z"/>
 </svg>


### PR DESCRIPTION
I have used this [web site](https://isotropic.co/tool/hex-color-to-css-filter/) to create the CSS filter to apply to the SVG image.