### PR TITLE
Fix typo in documentation

### DIFF
--- a/django_comments_xtd/templatetags/comments_xtd.py
+++ b/django_comments_xtd/templatetags/comments_xtd.py
@@ -395,7 +395,7 @@ class GetXtdCommentTreeNode(Node):
 def render_xtdcomment_tree(parser, token):
     """
     Render the nested comment tree structure posted to the given object.
-    By default uses the template ``django_comments_xtd/comments_tree.html``.
+    By default uses the template ``django_comments_xtd/comment_tree.html``.
 
     Syntax::
 

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -111,7 +111,7 @@ You will need to customize the following templates:
 * ``comments/form.html`` to include new fields.
 * ``comments/preview.html`` to preview new fields.
 * ``django_comments_xtd/email_confirmation_request.{txt|html}`` to add the new fields to the confirmation request, if it was necessary. This demo overrides them to include the ``title`` field in the mail.
-* ``django_comments_xtd/comments_tree.html`` to show the new field when displaying the comments. If your project doesn't allow nested comments you can use either this template or `comments/list.html``.
+* ``django_comments_xtd/comment_tree.html`` to show the new field when displaying the comments. If your project doesn't allow nested comments you can use either this template or `comments/list.html``.
 * ``django_comments_xtd/reply.html`` to show the new field when displaying the comment the user is replying to.
 
 

--- a/example/custom/README.md
+++ b/example/custom/README.md
@@ -3,7 +3,7 @@
 The Custom Demo exhibits how to extend django-comments-xtd. This demo used the same **articles** app present in the other two demos, plus:
 
  * A new django application, called `mycomments`, with a model `MyComment` that extends the `django_comments_xtd.models.MyComment` model with a field `title`.
- 
+
 To extend django-comments-xtd follow the next steps:
 
  1. Set up `COMMENTS_APP` to `django_comments_xtd`
@@ -13,5 +13,5 @@ To extend django-comments-xtd follow the next steps:
     * `comments/form.html` to include new fields.
     * `comments/preview.html` to preview new fields.
     * `django_comments_xtd/email_confirmation_request.{txt|html}` to add the new fields to the confirmation request, if it was necessary. This demo overrides them to include the `title` field in the mail.
-    * `django_comments_xtd/comments_tree.html` to show the new field when displaying the comments. If your project doesn't allow nested comments you can use either this template or `comments/list.html`.
+    * `django_comments_xtd/comment_tree.html` to show the new field when displaying the comments. If your project doesn't allow nested comments you can use either this template or `comments/list.html`.
     * `django_comments_xtd/reply.html` to show the new field when displaying the comment the user is replying to.


### PR DESCRIPTION
May remind user  the template overriding order somewhere in documentation.
For example:

1. use the Template filesystem loader to prioritize the extra template loading rather than App dirs

```python
TEMPLATES = [
    {
        "BACKEND": "django.template.backends.django.DjangoTemplates",
        "DIRS": [
            BASE_DIR / "base" / "templates",  # base/ is not an app, extra dir for FileSystemTemplate
        ],
        # ....
    },
]
```

2. Mind the app load order which decide the template loaded

```python
INSTALLED_APPS=
[
  'myblog', # go before
  # ....
  'django_comments_xtd'
]

# instead of
INSTALLED_APPS=
[
  'django_comments_xtd',
   # ....
  'myblog', # go before
]
```

Refer to django-contrib-comments, https://github.com/django/django-contrib-comments/blob/2.2.0/django_comments/templatetags/comments.py#L184

if the app specific template search is supported, it would be nicer.