### PR TITLE
fix issue-458

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -36,18 +36,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        python: ["3.10", "3.13"]
         django: ["4.1", "4.2", "5.0", "5.1"]
     steps:
       - uses: actions/checkout@v4
       - name: Python setup
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: "${{ env.PYTHON }}"
           cache: pip
       - name: Install tox and django
         run: pip install tox "django==${{ matrix.django }}"
       - name: Run unit tests
-        run: tox -e py3.13-django${{ matrix.django }}
+        run: tox -e py${{ matrix.python }}-django${{ matrix.django }}
 
   javascript:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -32,23 +32,39 @@ jobs:
       - name: Check syntax compliance
         run: pre-commit run --all-files --show-diff-on-failure
 
-  django:
+  python310:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10", "3.13"]
         django: ["4.1", "4.2", "5.0", "5.1"]
     steps:
       - uses: actions/checkout@v4
       - name: Python setup
         uses: actions/setup-python@v5
         with:
-          python-version: "${{ env.PYTHON }}"
+          python-version: "3.10"
           cache: pip
       - name: Install tox and django
         run: pip install tox "django==${{ matrix.django }}"
       - name: Run unit tests
-        run: tox -e py${{ matrix.python }}-django${{ matrix.django }}
+        run: tox -e py3.10-django${{ matrix.django }}
+
+  python313:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        django: ["4.1", "4.2", "5.0", "5.1"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Python setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+      - name: Install tox and django
+        run: pip install tox "django==${{ matrix.django }}"
+      - name: Run unit tests
+        run: tox -e py3.13-django${{ matrix.django }}
 
   javascript:
     runs-on: ubuntu-latest

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,10 @@ import os
 import sys
 from pathlib import Path
 
+plugins = [
+    "django_comments_xtd.tests.pytest_fixtures",
+]
+
 
 def pytest_configure(config):
     try:
@@ -14,3 +18,9 @@ def pytest_configure(config):
     import django
 
     django.setup()
+
+    # -------------------------------------
+    # Load fixtures listed in 'my_plugins'.
+
+    for plugin_module in plugins:
+        config.pluginmanager.import_plugin(plugin_module)

--- a/django_comments_xtd/api/frontend.py
+++ b/django_comments_xtd/api/frontend.py
@@ -89,8 +89,7 @@ class CommentBoxDriver:
         ctype = ContentType.objects.get_for_model(obj)
         queryset = cls.get_queryset(ctype, obj, request)
         ctype_slug = f"{ctype.app_label}-{ctype.model}"
-        ctype_key = f"{ctype.app_label}.{ctype.model}"
-        options = get_app_model_options(content_type=ctype_key)
+        options = get_app_model_options(content_type=ctype)
         d = {
             "comment_count": queryset.count(),
             "allow_comments": True,

--- a/django_comments_xtd/api/views.py
+++ b/django_comments_xtd/api/views.py
@@ -155,7 +155,7 @@ class ToggleFeedbackFlag(
             return Response(status=status.HTTP_204_NO_CONTENT)
 
     def perform_create(self, serializer):
-        f = getattr(views, f"perform_{self.request.data["flag"]}")
+        f = getattr(views, f"perform_{self.request.data['flag']}")
         self.created = f(self.request, serializer.validated_data["comment"])
 
 

--- a/django_comments_xtd/tests/pytest_fixtures.py
+++ b/django_comments_xtd/tests/pytest_fixtures.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.models import Site
+
+from django_comments_xtd.models import XtdComment
+from django_comments_xtd.tests.models import Article
+
+
+@pytest.fixture
+def an_article():
+    """Creates an article that can receive comments."""
+    article = Article.objects.create(
+        title="September", slug="september", body="During September..."
+    )
+    yield article
+    article.delete()
+
+
+@pytest.fixture
+def an_articles_comment(an_article):
+    """Send a comment to the article."""
+    article_ct = ContentType.objects.get(app_label="tests", model="article")
+    site = Site.objects.get(pk=1)
+    comment = XtdComment.objects.create(
+        content_type=article_ct,
+        object_pk=an_article.pk,
+        content_object=an_article,
+        site=site,
+        comment="First comment to the article.",
+        submit_date=datetime.now(),
+    )
+    yield comment
+    comment.delete()

--- a/django_comments_xtd/tests/test_serializers.py
+++ b/django_comments_xtd/tests/test_serializers.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from unittest.mock import patch
 
 import django_comments
+import pytest
 import pytz
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
@@ -11,7 +12,10 @@ from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APIClient
 
-from django_comments_xtd.api.serializers import ReadCommentSerializer
+from django_comments_xtd.api.serializers import (
+    FlagSerializer,
+    ReadCommentSerializer,
+)
 from django_comments_xtd.models import XtdComment
 from django_comments_xtd.signals import should_request_be_authorized
 from django_comments_xtd.tests.models import Article, authorize_api_post_comment
@@ -289,3 +293,21 @@ class RenderSubmitDateTestCase(TestCase):
         self.assertEqual(
             ser.data[0]["submit_date"], "2021-jan-10 11:15:00 +0100"
         )
+
+
+# ---------------------------------------------------------------------
+# Tests for FlagSerializer. Using pytest instead of unittest.
+
+
+@pytest.mark.django_db
+def test_flag_serializer_is_valid(an_articles_comment):
+    data = {"comment": an_articles_comment.pk, "flag": "report"}
+    ser = FlagSerializer(data=data)
+    assert ser.is_valid()
+
+
+@pytest.mark.django_db
+def test_flag_serializer_is_not_valid(an_articles_comment):
+    data = {"comment": an_articles_comment.pk, "flag": "non-supported-flag"}
+    ser = FlagSerializer(data=data)
+    assert not ser.is_valid()

--- a/django_comments_xtd/tests/test_utils.py
+++ b/django_comments_xtd/tests/test_utils.py
@@ -1,0 +1,104 @@
+# ruff: noqa: N802
+from unittest.mock import MagicMock
+
+import pytest
+
+from django_comments_xtd import utils
+from django_comments_xtd.conf.defaults import COMMENTS_XTD_APP_MODEL_OPTIONS
+
+
+@pytest.mark.django_db
+def test_send_mail_uses_EmailThread(monkeypatch):
+    monkeypatch.setattr(utils.settings, "COMMENTS_XTD_THREADED_EMAILS", True)
+    utils.send_mail(
+        "the subject",
+        "the message",
+        "helpdesk@example.com",
+        ["fulanito@example.com"],
+        html="<p>The message.</p>",
+    )
+    assert utils.mail_sent_queue.get()
+
+
+@pytest.mark.django_db
+def test_send_mail_uses__send_amil(monkeypatch):
+    _send_mail_mock = MagicMock()
+    monkeypatch.setattr(utils, "_send_mail", _send_mail_mock)
+    monkeypatch.setattr(utils.settings, "COMMENTS_XTD_THREADED_EMAILS", False)
+    utils.send_mail(
+        "the subject",
+        "the message",
+        "helpdesk@example.com",
+        ["fulanito@example.com"],
+        html="<p>The message.</p>",
+    )
+    _send_mail_mock.assert_called()
+
+
+# ----------------------------------------------
+@pytest.mark.django_db
+def test_get_app_model_options_without_args():
+    options = utils.get_app_model_options()
+    assert options == COMMENTS_XTD_APP_MODEL_OPTIONS["default"]
+
+
+mock_options_settings = {
+    "default": {
+        "who_can_post": "all",
+        "allow_flagging": True,
+        "allow_feedback": True,
+        "show_feedback": True,
+    },
+    "tests.article": {
+        "allow_flagging": False,
+        "allow_feedback": False,
+        "show_feedback": False,
+    },
+}
+
+
+@pytest.mark.django_db
+def test_get_app_model_options_with_comment(an_articles_comment, monkeypatch):
+    monkeypatch.setattr(
+        utils.settings,
+        "COMMENTS_XTD_APP_MODEL_OPTIONS",
+        mock_options_settings,
+    )
+    options = utils.get_app_model_options(comment=an_articles_comment)
+    assert options == {
+        "who_can_post": "all",
+        "allow_flagging": False,
+        "allow_feedback": False,
+        "show_feedback": False,
+    }
+
+
+@pytest.mark.django_db
+def test_get_app_model_options_with_content_type_None(monkeypatch):
+    monkeypatch.setattr(
+        utils.settings,
+        "COMMENTS_XTD_APP_MODEL_OPTIONS",
+        mock_options_settings,
+    )
+    options = utils.get_app_model_options(content_type=None)
+    assert options == mock_options_settings["default"]
+
+
+@pytest.mark.django_db
+def test_get_app_model_options_with_content_type_valid(
+    an_articles_comment, monkeypatch
+):
+    monkeypatch.setattr(
+        utils.settings,
+        "COMMENTS_XTD_APP_MODEL_OPTIONS",
+        mock_options_settings,
+    )
+    options = utils.get_app_model_options(
+        content_type=an_articles_comment.content_type
+    )
+    assert options == {  # The options declared above for 'tests.article'
+        "who_can_post": "all",
+        "allow_flagging": False,
+        "allow_feedback": False,
+        "show_feedback": False,
+    }

--- a/django_comments_xtd/views.py
+++ b/django_comments_xtd/views.py
@@ -125,9 +125,7 @@ def on_comment_will_be_posted(sender, comment, request, **kwargs):
     else:
         user_is_authenticated = False
 
-    ct = comment.get("content_type")
-    ct_str = f"{ct.app_label}.{ct.model}"
-    options = get_app_model_options(content_type=ct_str)
+    options = get_app_model_options(comment=comment)
 
     return not (  # Return False to reject comment.
         options["who_can_post"] == "users" and not user_is_authenticated
@@ -325,8 +323,7 @@ def reply(request, cid):
     except XtdComment.DoesNotExist as exc:
         raise Http404(exc) from exc
 
-    ct_str = f"{comment.content_type.app_label}.{comment.content_type.model}"
-    options = get_app_model_options(content_type=ct_str)
+    options = get_app_model_options(comment)
 
     if not request.user.is_authenticated and options["who_can_post"] == "users":
         path = request.build_absolute_uri()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,9 +132,7 @@ csi_add_script_to_html_output = False
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "documentation_font": "Open Sans",
-    "monospace_font": "Ubuntu Mono",
-    "monospace_font_size": "1.1rem",
+    "monospace_font_size": ".90rem",
 
     "style": "green",
     "style_header_neutral": True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
+requires-python = ">=3.10"
 authors = [
     {name = "Daniela Rus Morales", email = "danirus@eml.cc"}
 ]
@@ -44,14 +45,14 @@ dev = [
     "pytest-cov >=6.0, <6.1",
     "pytest-django >=4.9, <4.10",
     "ruff >=0.11.0, <1",
-    "tox >=4.23, <4.24",
+    "tox >=4.25, <4.26",
 ]
 docs = [
     "sphinx >=8, <9",
     "myst-parser >=4.0.0, <4.1",
     "sphinx-colorschemed-images >=0.2.2",
     "sphinx-copybutton >=0.5.2, <1.0.0",
-    "sphinx-nefertiti >=0.7.3",
+    "sphinx-nefertiti >=0.7.5",
 ]
 
 [tool.coverage.run]
@@ -76,6 +77,7 @@ exclude = [
 version = {attr = "django_comments_xtd.get_version"}
 
 [tool.ruff]
+target-version = "py310"
 exclude = [
     "docs/",
     "venv/",
@@ -92,7 +94,6 @@ extend-select = [
     # "FURB",# refurb (modernising code)
     "I",   # isort
     "ICN", # flake8-import-conventions
-    "ISC", # flake8-implicit-str-concat
     "N",   # pep8-naming
     "PERF",# perflint (performance anti-patterns)
     "PGH", # pygrep-hooks

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,15 @@ django_find_project = false
 
 [tox]
 skipsdist = True
-envlist = py3.13-django{4.1,4.2,5.0,5.1}
+envlist =
+    py3.10-django4.1
+    py3.10-django4.2
+    py3.10-django5.0
+    py3.10-django5.1
+    py3.13-django4.1
+    py3.13-django4.2
+    py3.13-django5.0
+    py3.13-django5.1
 
 [testenv]
 changedir = {toxinidir}/django_comments_xtd
@@ -19,13 +27,15 @@ commands =
     ; py.test -rw --cov-config .coveragerc --cov django_comments_xtd
 deps =
     .[dev]
+    py3.10-django4.1: django>=4.1,<4.2
+    py3.10-django4.1: djangorestframework>=3.12,<3.16
+    py3.10-django4.1: django-contrib-comments>=2.2,<2.3
     py3.13-django4.1: django>=4.1,<4.2
     py3.13-django4.2: django>=4.2,<4.3
     py3.13-django5.0: django>=5.0,<5.1
     py3.13-django5.1: django>=5.1,<5.2
     py3.13-django{4.1,4.2,5.0,5.1}: djangorestframework>=3.12,<3.16
     py3.13-django{4.1,4.2,5.0,5.1}: django-contrib-comments>=2.2,<2.3
-    ; py3.13-django{4.1,4.2,5.0,5.1}: pytz
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
     DJANGO_SETTINGS_MODULE=django_comments_xtd.tests.settings


### PR DESCRIPTION
This PR fixes issue #458.
* Rewrite two f-strings that wouldn't otherwise be compatible with Python 3.10 (initial version of Python with which this package promises to be compatible with).
* Add a couple of tests to cover it.
* Include Python 3.10 in the GitHub Actions matrix.
* Fixes the code of `utils.get_app_model_options`, add tests.