### PR TITLE
Prepare release 2.10.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [2.10.8] - 2025-08-06
+
+* Fixes [issue-465](https://github.com/danirus/django-comments-xtd/issues/465): Convert view `preview_user_avatar` in a Class-based-view that inherits from `DefaultsMixin`, so that it returns a JSON response.
+
 ## [2.10.7] - 2025-07-10
 
 * Fixes [issue-462](https://github.com/danirus/django-comments-xtd/issues/462): function `get_app_model_options` did not work as expected when passing commenting options only through the `"default"` key.

--- a/django_comments_xtd/__init__.py
+++ b/django_comments_xtd/__init__.py
@@ -17,7 +17,7 @@ def get_form():
     return import_string(settings.COMMENTS_XTD_FORM_CLASS)
 
 
-VERSION = (2, 10, 7, "f", 0)  # following PEP 440
+VERSION = (2, 10, 8, "f", 0)  # following PEP 440
 
 
 def get_version():

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ copyright = u'2024, Daniela Rus Morales'
 # The short X.Y version.
 version = '2.10'
 # The full version, including alpha/beta/rc tags.
-release = '2.10.7'
+release = '2.10.8'
 
 releases = [
     "latest",

--- a/docs/javascript.rst
+++ b/docs/javascript.rst
@@ -131,8 +131,8 @@ Which results in:
     │   ├── commentform.test.jsx
     │   ├── reducer.test.jsx
     │   └── lib.test.js
-    ├── django-comments-xtd-2.10.7.js
-    └── django-comments-xtd-2.10.7.min.js
+    ├── django-comments-xtd-2.10.8.js
+    └── django-comments-xtd-2.10.8.min.js
 
 The application entry point is located inside the ``index.js`` file. The
 ``props`` passed to the **CommentBox** object are those declared in the

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1192,7 +1192,7 @@ Be sure your ``blog/post_detail.html`` looks like the following:
     <script
     type="text/javascript"
     src="{% url 'javascript-catalog' %}"></script>
-    <script src="{% static 'django_comments_xtd/js/django-comments-xtd-2.10.7.js' %}"></script>
+    <script src="{% static 'django_comments_xtd/js/django-comments-xtd-2.10.8.js' %}"></script>
     <script>
     window.addEventListener('DOMContentLoaded', (_) => {
         const tooltipQs = '[data-bs-toggle="tooltip"]';

--- a/example/comp/templates/articles/article_detail.html
+++ b/example/comp/templates/articles/article_detail.html
@@ -56,5 +56,5 @@
    polling_interval: 2000
  };
 </script>
-<script src="{% static 'django_comments_xtd/js/django-comments-xtd-2.10.7.min.js' %}"></script>
+<script src="{% static 'django_comments_xtd/js/django-comments-xtd-2.10.8.min.js' %}"></script>
 {% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "django-comments-xtd-plugins",
-  "version": "2.10.7",
+  "version": "2.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "django-comments-xtd-plugins",
-      "version": "2.10.7",
+      "version": "2.10.8",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.25.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "django-comments-xtd-plugins",
-  "version": "2.10.7",
+  "version": "2.10.8",
   "description": "Provides django-comments-xtd reactjs plugin",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Prepares release 2.10.8, which includes a fix for issue #465:
* Convert API view `preview_user_avatar` in a class-based-view, `PreviewUserAvatar`, that inherits from `DefaultsMixin`, so that it returns a JSON response. 